### PR TITLE
Fix authentication security and improve error handling

### DIFF
--- a/Sources/UmeroKit/Geo/UGeoTracks.swift
+++ b/Sources/UmeroKit/Geo/UGeoTracks.swift
@@ -31,10 +31,10 @@ extension UGeoTracks {
 extension UGeoTracks: Decodable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: MainKey.self)
-    let artistsContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .tracks)
+    let tracksContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .tracks)
 
-    self.tracks = try artistsContainer.decode([UTrack].self, forKey: .track)
-    self.attributes = try artistsContainer.decode(UGeoAttributes.self, forKey: .attributes)
+    self.tracks = try tracksContainer.decode([UTrack].self, forKey: .track)
+    self.attributes = try tracksContainer.decode(UGeoAttributes.self, forKey: .attributes)
   }
 }
 

--- a/Sources/UmeroKit/UAuthDataRequest.swift
+++ b/Sources/UmeroKit/UAuthDataRequest.swift
@@ -67,7 +67,7 @@ struct UAuthDataRequest {
     // Validate session key is present and not empty
     guard !response.session.key.isEmpty else {
         throw UmeroKitError.authenticationFailed(
-            code: response.error ?? 0,
+            code: response.error ?? -1,
             message: response.message ?? "Authentication failed: Session key is missing"
         )
     }

--- a/Sources/UmeroKit/UAuthDataRequest.swift
+++ b/Sources/UmeroKit/UAuthDataRequest.swift
@@ -52,12 +52,10 @@ struct UAuthDataRequest {
       URLQueryItem(name: key, value: value)
     }
     
-    // Get the query string (without the leading ?)
-    guard let queryString = urlComponents.url?.absoluteString.dropFirst() else {
+    // Get the POST body data from the URL components
+    guard let postData = urlComponents.query?.data(using: .utf8) else {
       throw UmeroKitError.invalidURL
     }
-    
-    let postData = String(queryString).data(using: .utf8)
 
     let request = UDataPostRequest<USession>(url: components.url, data: postData)
     let response = try await request.response()

--- a/Sources/UmeroKit/UDataRequest.swift
+++ b/Sources/UmeroKit/UDataRequest.swift
@@ -48,10 +48,15 @@ public struct UDataPostRequest<Model: Codable>: Sendable {
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = "POST"
     urlRequest.httpBody = data
+    urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
 
     let (urlRequestData, _) = try await URLSession.shared.data(for: urlRequest)
 
-    print(try urlRequestData.printJSON())
+    #if DEBUG
+    if let jsonString = try? urlRequestData.printJSON() {
+      print(jsonString)
+    }
+    #endif
 
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
@@ -68,6 +73,7 @@ public struct UDataPostRequest<Model: Codable>: Sendable {
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = "POST"
     urlRequest.httpBody = data
+    urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
     let (urlRequestData, _) = try await URLSession.shared.data(for: urlRequest)
     return urlRequestData
   }

--- a/Sources/UmeroKit/UDataRequest.swift
+++ b/Sources/UmeroKit/UDataRequest.swift
@@ -41,16 +41,7 @@ public struct UDataPostRequest<Model: Codable>: Sendable {
   /// Write data to the last.fm endpoint that
   /// the URL request defines.
   public func response() async throws -> Model {
-    guard let url else {
-      throw UmeroKitError.invalidURL
-    }
-
-    var urlRequest = URLRequest(url: url)
-    urlRequest.httpMethod = "POST"
-    urlRequest.httpBody = data
-    urlRequest.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-
-    let (urlRequestData, _) = try await URLSession.shared.data(for: urlRequest)
+    let urlRequestData = try await responseData()
 
     #if DEBUG
     if let jsonString = try? urlRequestData.printJSON() {


### PR DESCRIPTION
## Security Fix
- Credentials now sent in POST body instead of query string (per Last.fm API spec)
- Added Content-Type header to POST requests

## Bug Fixes
- Guard debug print statements with #if DEBUG to prevent crashes
- Validate session key is present and not empty

## Changes
- UAuthDataRequest: Send credentials in POST body, validate session key
- UDataRequest: Add Content-Type header, guard debug prints
- Package.swift: Remove test executable target