### PR TITLE
feat: Implement all 14 user endpoints for Last.fm API

### DIFF
--- a/LASTFM_API_COVERAGE.md
+++ b/LASTFM_API_COVERAGE.md
@@ -7,8 +7,8 @@ This report analyzes the coverage of Last.fm API endpoints in UmeroKit, comparin
 ## Summary
 
 - **Total Endpoints Defined**: 48
-- **Total Endpoints Implemented**: 19
-- **Coverage**: 39.6%
+- **Total Endpoints Implemented**: 48
+- **Coverage**: 100%
 
 ## Endpoint Coverage by Category
 
@@ -17,72 +17,72 @@ This report analyzes the coverage of Last.fm API endpoints in UmeroKit, comparin
 | Endpoint | Defined | Implemented | Status |
 |----------|---------|-------------|--------|
 | `album.getInfo` | ✅ | ✅ | **COMPLETE** |
-| `album.getTags` | ✅ | ❌ | **MISSING** |
+| `album.getTags` | ✅ | ✅ | **COMPLETE** |
 | `album.getTopTags` | ✅ | ✅ | **COMPLETE** |
 | `album.search` | ✅ | ✅ | **COMPLETE** |
 
-**Missing**: 1 endpoint (`album.getTags`)
+**Missing**: 0 endpoints - **FULLY COVERED**
 
 ### Artist Endpoints (`artist.*`)
 
 | Endpoint | Defined | Implemented | Status |
 |----------|---------|-------------|--------|
 | `artist.getInfo` | ✅ | ✅ | **COMPLETE** |
-| `artist.getTags` | ✅ | ❌ | **MISSING** |
-| `artist.getTopTags` | ✅ | ❌ | **MISSING** |
-| `artist.getTopAlbums` | ✅ | ❌ | **MISSING** |
-| `artist.getTopTracks` | ✅ | ❌ | **MISSING** |
+| `artist.getTags` | ✅ | ✅ | **COMPLETE** |
+| `artist.getTopTags` | ✅ | ✅ | **COMPLETE** |
+| `artist.getTopAlbums` | ✅ | ✅ | **COMPLETE** |
+| `artist.getTopTracks` | ✅ | ✅ | **COMPLETE** |
 | `artist.search` | ✅ | ✅ | **COMPLETE** |
-| `artist.getSimilar` | ✅ | ❌ | **MISSING** |
+| `artist.getSimilar` | ✅ | ✅ | **COMPLETE** |
 
-**Missing**: 5 endpoints
+**Missing**: 0 endpoints - **FULLY COVERED**
 
 ### Track Endpoints (`track.*`)
 
 | Endpoint | Defined | Implemented | Status |
 |----------|---------|-------------|--------|
-| `track.getInfo` | ✅ | ❌ | **MISSING** |
-| `track.getTags` | ✅ | ❌ | **MISSING** |
-| `track.getSimilar` | ✅ | ❌ | **MISSING** |
-| `track.getTopTags` | ✅ | ❌ | **MISSING** |
+| `track.getInfo` | ✅ | ✅ | **COMPLETE** |
+| `track.getTags` | ✅ | ✅ | **COMPLETE** |
+| `track.getSimilar` | ✅ | ✅ | **COMPLETE** |
+| `track.getTopTags` | ✅ | ✅ | **COMPLETE** |
 | `track.search` | ✅ | ✅ | **COMPLETE** |
 
-**Missing**: 4 endpoints
+**Missing**: 0 endpoints - **FULLY COVERED**
 
 ### User Endpoints (`user.*`)
 
 | Endpoint | Defined | Implemented | Status |
 |----------|---------|-------------|--------|
-| `user.getFriends` | ✅ | ❌ | **MISSING** |
-| `user.getPersonalTags` | ✅ | ❌ | **MISSING** |
-| `user.getRecentTracks` | ✅ | ❌ | **MISSING** |
-| `user.getInfo` | ✅ | ❌ | **MISSING** |
-| `user.getTags` | ✅ | ❌ | **MISSING** |
-| `user.getLovedTracks` | ✅ | ❌ | **MISSING** |
-| `user.getTopArtists` | ✅ | ❌ | **MISSING** |
-| `user.getTopAlbums` | ✅ | ❌ | **MISSING** |
-| `user.getTopTracks` | ✅ | ❌ | **MISSING** |
-| `user.getTopTags` | ✅ | ❌ | **MISSING** |
-| `user.getWeeklyAlbumChart` | ✅ | ❌ | **MISSING** |
-| `user.getWeeklyArtistChart` | ✅ | ❌ | **MISSING** |
-| `user.getWeeklyChartList` | ✅ | ❌ | **MISSING** |
-| `user.getWeeklyTrackChart` | ✅ | ❌ | **MISSING** |
+| `user.getFriends` | ✅ | ✅ | **COMPLETE** |
+| `user.getPersonalTags` | ✅ | ✅ | **COMPLETE** |
+| `user.getRecentTracks` | ✅ | ✅ | **COMPLETE** |
+| `user.getInfo` | ✅ | ✅ | **COMPLETE** |
+| `user.getTags` | ✅ | ✅ | **COMPLETE** |
+| `user.getLovedTracks` | ✅ | ✅ | **COMPLETE** |
+| `user.getTopArtists` | ✅ | ✅ | **COMPLETE** |
+| `user.getTopAlbums` | ✅ | ✅ | **COMPLETE** |
+| `user.getTopTracks` | ✅ | ✅ | **COMPLETE** |
+| `user.getTopTags` | ✅ | ✅ | **COMPLETE** |
+| `user.getWeeklyAlbumChart` | ✅ | ✅ | **COMPLETE** |
+| `user.getWeeklyArtistChart` | ✅ | ✅ | **COMPLETE** |
+| `user.getWeeklyChartList` | ✅ | ✅ | **COMPLETE** |
+| `user.getWeeklyTrackChart` | ✅ | ✅ | **COMPLETE** |
 
-**Missing**: 14 endpoints (all user endpoints are missing)
+**Missing**: 0 endpoints - **FULLY COVERED**
 
 ### Tag Endpoints (`tag.*`)
 
 | Endpoint | Defined | Implemented | Status |
 |----------|---------|-------------|--------|
 | `tag.getInfo` | ✅ | ✅ | **COMPLETE** |
-| `tag.getTopArtists` | ✅ | ❌ | **MISSING** |
-| `tag.getTopAlbums` | ✅ | ❌ | **MISSING** |
-| `tag.getTopTracks` | ✅ | ❌ | **MISSING** |
+| `tag.getTopArtists` | ✅ | ✅ | **COMPLETE** |
+| `tag.getTopAlbums` | ✅ | ✅ | **COMPLETE** |
+| `tag.getTopTracks` | ✅ | ✅ | **COMPLETE** |
 | `tag.getTopTags` | ✅ | ✅ | **COMPLETE** |
-| `tag.getSimilar` | ✅ | ❌ | **MISSING** |
-| `tag.getWeeklyChartList` | ✅ | ❌ | **MISSING** |
+| `tag.getSimilar` | ✅ | ✅ | **COMPLETE** |
+| `tag.getWeeklyChartList` | ✅ | ✅ | **COMPLETE** |
 
-**Missing**: 5 endpoints
+**Missing**: 0 endpoints - **FULLY COVERED**
 
 ### Chart Endpoints (`chart.*`)
 
@@ -130,83 +130,97 @@ This report analyzes the coverage of Last.fm API endpoints in UmeroKit, comparin
 
 ## Implemented Methods Summary
 
-### Currently Implemented (19 methods)
+### Currently Implemented (48 methods)
 
+**Album Endpoints (4):**
 1. ✅ `album.getInfo` - Get album metadata (2 overloads: by name+artist, by MBID)
-2. ✅ `album.getTopTags` - Get top tags for an album
-3. ✅ `album.search` - Search for albums
-4. ✅ `artist.getInfo` - Get artist metadata
-5. ✅ `artist.search` - Search for artists
-6. ✅ `track.search` - Search for tracks
-7. ✅ `tag.getInfo` - Get tag information
-8. ✅ `tag.getTopTags` - Get top tags globally
-9. ✅ `chart.getTopArtists` - Get top artists chart
-10. ✅ `chart.getTopTracks` - Get top tracks chart
-11. ✅ `chart.getTopTags` - Get top tags chart
-12. ✅ `geo.getTopArtists` - Get top artists by country
-13. ✅ `geo.getTopTracks` - Get top tracks by country
-14. ✅ `auth.getMobileSession` - Authenticate user
-15. ✅ `track.updateNowPlaying` - Update now playing status
-16. ✅ `track.scrobble` - Scrobble a track
-17. ✅ `track.love` - Love/unlove a track
-18. ✅ `checkLogin` - Verify credentials (helper method)
+2. ✅ `album.getTags` - Get tags applied by a user to an album
+3. ✅ `album.getTopTags` - Get top tags for an album
+4. ✅ `album.search` - Search for albums
 
-## Missing Implementations (29 endpoints)
+**Artist Endpoints (7):**
+5. ✅ `artist.getInfo` - Get artist metadata
+6. ✅ `artist.getTags` - Get tags applied by a user to an artist
+7. ✅ `artist.getTopTags` - Get top tags for an artist
+8. ✅ `artist.getTopAlbums` - Get top albums for an artist
+9. ✅ `artist.getTopTracks` - Get top tracks for an artist
+10. ✅ `artist.getSimilar` - Get similar artists
+11. ✅ `artist.search` - Search for artists
 
-### High Priority (User Data)
-All user endpoints require authentication and are commonly used:
-- `user.getRecentTracks` - Get user's recent scrobbles
-- `user.getLovedTracks` - Get user's loved tracks
-- `user.getInfo` - Get user profile information
-- `user.getTopArtists` - Get user's top artists
-- `user.getTopAlbums` - Get user's top albums
-- `user.getTopTracks` - Get user's top tracks
-- `user.getTopTags` - Get user's top tags
-- `user.getWeeklyAlbumChart` - Get weekly album chart for user
-- `user.getWeeklyArtistChart` - Get weekly artist chart for user
-- `user.getWeeklyTrackChart` - Get weekly track chart for user
-- `user.getWeeklyChartList` - Get list of available weekly charts
-- `user.getFriends` - Get user's friends
-- `user.getPersonalTags` - Get user's personal tags
-- `user.getTags` - Get tags applied by user
+**Track Endpoints (5):**
+12. ✅ `track.getInfo` - Get track metadata
+13. ✅ `track.getTags` - Get tags applied by a user to a track
+14. ✅ `track.getTopTags` - Get top tags for a track
+15. ✅ `track.getSimilar` - Get similar tracks
+16. ✅ `track.search` - Search for tracks
 
-### Medium Priority (Track & Artist Details)
-- `track.getInfo` - Get track metadata
-- `track.getTags` - Get tags for a track
-- `track.getTopTags` - Get top tags for a track
-- `track.getSimilar` - Get similar tracks
-- `artist.getTopAlbums` - Get top albums by artist
-- `artist.getTopTracks` - Get top tracks by artist
-- `artist.getSimilar` - Get similar artists
-- `artist.getTags` - Get tags for an artist
-- `artist.getTopTags` - Get top tags for an artist
+**Tag Endpoints (7):**
+17. ✅ `tag.getInfo` - Get tag information
+18. ✅ `tag.getTopArtists` - Get top artists for a tag
+19. ✅ `tag.getTopAlbums` - Get top albums for a tag
+20. ✅ `tag.getTopTracks` - Get top tracks for a tag
+21. ✅ `tag.getTopTags` - Get top tags globally
+22. ✅ `tag.getSimilar` - Get similar tags
+23. ✅ `tag.getWeeklyChartList` - Get weekly chart list for a tag
 
-### Lower Priority (Album & Tag Details)
-- `album.getTags` - Get tags for an album
-- `tag.getTopArtists` - Get top artists for a tag
-- `tag.getTopAlbums` - Get top albums for a tag
-- `tag.getTopTracks` - Get top tracks for a tag
-- `tag.getSimilar` - Get similar tags
-- `tag.getWeeklyChartList` - Get weekly chart list for a tag
+**User Endpoints (14):**
+24. ✅ `user.getInfo` - Get user profile information
+25. ✅ `user.getTags` - Get tags applied by a user
+26. ✅ `user.getTopTags` - Get top tags for a user
+27. ✅ `user.getTopArtists` - Get top artists for a user
+28. ✅ `user.getTopAlbums` - Get top albums for a user
+29. ✅ `user.getTopTracks` - Get top tracks for a user
+30. ✅ `user.getRecentTracks` - Get user's recent scrobbles
+31. ✅ `user.getLovedTracks` - Get user's loved tracks
+32. ✅ `user.getWeeklyChartList` - Get list of available weekly charts
+33. ✅ `user.getWeeklyAlbumChart` - Get weekly album chart for user
+34. ✅ `user.getWeeklyArtistChart` - Get weekly artist chart for user
+35. ✅ `user.getWeeklyTrackChart` - Get weekly track chart for user
+36. ✅ `user.getFriends` - Get user's friends
+37. ✅ `user.getPersonalTags` - Get user's personal tags
+
+**Chart Endpoints (3):**
+38. ✅ `chart.getTopArtists` - Get top artists chart
+39. ✅ `chart.getTopTracks` - Get top tracks chart
+40. ✅ `chart.getTopTags` - Get top tags chart
+
+**Geo Endpoints (2):**
+41. ✅ `geo.getTopArtists` - Get top artists by country
+42. ✅ `geo.getTopTracks` - Get top tracks by country
+
+**Auth Endpoints (1):**
+43. ✅ `auth.getMobileSession` - Authenticate user
+
+**Scrobbling Endpoints (2):**
+44. ✅ `track.updateNowPlaying` - Update now playing status
+45. ✅ `track.scrobble` - Scrobble a track
+
+**Love Endpoints (1):**
+46. ✅ `track.love` - Love/unlove a track
+
+**Helper Methods:**
+47. ✅ `checkLogin` - Verify credentials (helper method)
+
 
 ## Notes
 
-1. **User Endpoints**: All user endpoints are currently missing. These require authentication and are essential for user-specific features.
+1. **Complete Coverage**: All Last.fm API endpoints are now fully implemented! ✅
 
-2. **Track Endpoints**: Most track detail endpoints are missing. Only `track.search` is implemented.
+2. **User Endpoints**: All 14 user endpoints have been implemented with full authentication support. These endpoints require session key authentication and provide access to user-specific data.
 
-3. **Artist Endpoints**: Missing many artist detail endpoints like `getTopAlbums`, `getTopTracks`, `getSimilar`.
+3. **Search Functionality**: All search endpoints (album, artist, track) are implemented.
 
-4. **Complete Coverage**: Chart, Geo, Auth, and Scrobbling endpoints are fully covered.
-
-5. **Search Functionality**: All search endpoints (album, artist, track) are implemented.
+4. **Recent Updates**: 
+   - Artist endpoints achieved 100% coverage with implementation of `getTopAlbums`, `getTopTracks`, `getSimilar`, `getTags`, and `getTopTags`
+   - Track endpoints achieved 100% coverage with implementation of `getInfo`, `getTags`, `getTopTags`, and `getSimilar`
+   - Tag endpoints achieved 100% coverage with implementation of `getTopArtists`, `getTopAlbums`, `getTopTracks`, `getSimilar`, and `getWeeklyChartList`
+   - User endpoints achieved 100% coverage with implementation of all 14 user endpoints
 
 ## Recommendations
 
-1. **Priority 1**: Implement user endpoints (`user.getRecentTracks`, `user.getLovedTracks`, `user.getInfo`, etc.)
-2. **Priority 2**: Implement track detail endpoints (`track.getInfo`, `track.getTags`, `track.getSimilar`)
-3. **Priority 3**: Implement artist detail endpoints (`artist.getTopAlbums`, `artist.getTopTracks`, `artist.getSimilar`)
-4. **Priority 4**: Implement remaining album and tag endpoints
+1. **Testing**: All endpoints should be tested against the Last.fm API to ensure proper functionality and error handling.
+2. **Documentation**: Consider adding more detailed examples and usage documentation for user endpoints.
+3. **Future Enhancements**: Consider adding convenience methods for working with weekly charts (e.g., helper methods to convert timestamps to Date objects).
 
 ## Files Reference
 

--- a/Sources/UmeroKit/Models/UUserFriends.swift
+++ b/Sources/UmeroKit/Models/UUserFriends.swift
@@ -128,4 +128,3 @@ extension UUserFriends: Encodable {
     try friendsContainer.encode(attributes, forKey: .attributes)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserFriends.swift
+++ b/Sources/UmeroKit/Models/UUserFriends.swift
@@ -49,16 +49,15 @@ extension UUserFriend: Decodable {
     self.image = try container.decodeIfPresent([UImage].self, forKey: .image)
     
     let subscriberString = try container.decodeIfPresent(String.self, forKey: .subscriber)
-    self.subscriber = subscriberString == "1"
+    self.subscriber = subscriberString.map { $0 == "1" }
     
     // Date parsing
     if let dateContainer = try? container.nestedContainer(keyedBy: DateKeys.self, forKey: .date) {
       let timestampString = try dateContainer.decode(String.self, forKey: .timestamp)
-      if let timestamp = Int(timestampString) {
-        self.date = Date(timeIntervalSince1970: TimeInterval(timestamp))
-      } else {
-        self.date = nil
+      guard let timestamp = Int(timestampString) else {
+        throw UmeroKitError.invalidDataFormat("Date timestamp for friend '\(name)' is not a valid number.")
       }
+      self.date = Date(timeIntervalSince1970: TimeInterval(timestamp))
     } else {
       self.date = nil
     }

--- a/Sources/UmeroKit/Models/UUserFriends.swift
+++ b/Sources/UmeroKit/Models/UUserFriends.swift
@@ -1,0 +1,131 @@
+//
+//  UUserFriends.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a friend of a user.
+public struct UUserFriend {
+  /// The friend's username.
+  public let name: String
+  
+  /// The friend's profile image.
+  public let image: [UImage]?
+  
+  /// The friend's Last.fm profile URL.
+  public let url: URL
+  
+  /// The date when the users became friends.
+  public let date: Date?
+  
+  /// Whether the friend is a subscriber.
+  public let subscriber: Bool?
+}
+
+extension UUserFriend {
+  enum CodingKeys: String, CodingKey {
+    case name
+    case image
+    case url
+    case subscriber
+    case date
+  }
+  
+  enum DateKeys: String, CodingKey {
+    case timestamp = "uts"
+    case text = "#text"
+  }
+}
+
+extension UUserFriend: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    self.name = try container.decode(String.self, forKey: .name)
+    self.url = try container.decode(URL.self, forKey: .url)
+    self.image = try container.decodeIfPresent([UImage].self, forKey: .image)
+    
+    let subscriberString = try container.decodeIfPresent(String.self, forKey: .subscriber)
+    self.subscriber = subscriberString == "1"
+    
+    // Date parsing
+    if let dateContainer = try? container.nestedContainer(keyedBy: DateKeys.self, forKey: .date) {
+      let timestampString = try dateContainer.decode(String.self, forKey: .timestamp)
+      if let timestamp = Int(timestampString) {
+        self.date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+      } else {
+        self.date = nil
+      }
+    } else {
+      self.date = nil
+    }
+  }
+}
+
+extension UUserFriend: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(url, forKey: .url)
+    try container.encodeIfPresent(image, forKey: .image)
+    
+    if let subscriber {
+      try container.encode(subscriber ? "1" : "0", forKey: .subscriber)
+    }
+    
+    if let date {
+      var dateContainer = container.nestedContainer(keyedBy: DateKeys.self, forKey: .date)
+      try dateContainer.encode(String(Int(date.timeIntervalSince1970)), forKey: .timestamp)
+    }
+  }
+}
+
+/// Represents a list of friends for a user.
+public struct UUserFriends {
+  /// Collection of friends.
+  public let friends: [UUserFriend]
+  
+  /// The attributes of the request like user, page, total pages, and total count.
+  public let attributes: UUserTopItemsAttributes
+}
+
+extension UUserFriends {
+  enum MainKey: String, CodingKey {
+    case friends
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case user
+    case attributes = "@attr"
+  }
+}
+
+extension UUserFriends: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let friendsContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .friends)
+    
+    // Handle both single friend and array of friends
+    if let singleFriend = try? friendsContainer.decode(UUserFriend.self, forKey: .user) {
+      self.friends = [singleFriend]
+    } else {
+      self.friends = try friendsContainer.decode([UUserFriend].self, forKey: .user)
+    }
+    
+    self.attributes = try friendsContainer.decode(UUserTopItemsAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserFriends: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var friendsContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .friends)
+    
+    try friendsContainer.encode(friends, forKey: .user)
+    try friendsContainer.encode(attributes, forKey: .attributes)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserInfo.swift
+++ b/Sources/UmeroKit/Models/UUserInfo.swift
@@ -107,18 +107,24 @@ extension UUserInfo: Decodable {
       self.subscriber = nil
     }
     
-    if let playcountString = try userContainer.decodeIfPresent(String.self, forKey: .playcount), !playcountString.isEmpty {
+    if let playcountString = try userContainer.decodeIfPresent(String.self, forKey: .playcount),
+       !playcountString.isEmpty {
       guard let playcountValue = Double(playcountString) else {
-        throw UmeroKitError.invalidDataFormat("Playcount is not a valid number for user '\(name)'")
+        throw UmeroKitError.invalidDataFormat(
+          "Playcount is not a valid number for user '\(name)'"
+        )
       }
       self.playcount = playcountValue
     } else {
       self.playcount = nil
     }
     
-    if let playlistsString = try userContainer.decodeIfPresent(String.self, forKey: .playlists), !playlistsString.isEmpty {
+    if let playlistsString = try userContainer.decodeIfPresent(String.self, forKey: .playlists),
+       !playlistsString.isEmpty {
       guard let playlistsValue = Int(playlistsString) else {
-        throw UmeroKitError.invalidDataFormat("Playlists is not a valid number for user '\(name)'")
+        throw UmeroKitError.invalidDataFormat(
+          "Playlists is not a valid number for user '\(name)'"
+        )
       }
       self.playlists = playlistsValue
     } else {
@@ -160,4 +166,3 @@ extension UUserInfo: Encodable {
     try userContainer.encodeIfPresent(registered, forKey: .registered)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserInfo.swift
+++ b/Sources/UmeroKit/Models/UUserInfo.swift
@@ -1,0 +1,163 @@
+//
+//  UUserInfo.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents user information from Last.fm.
+public struct UUserInfo {
+  /// The user's username.
+  public let name: String
+  
+  /// The user's real name (if set).
+  public let realname: String?
+  
+  /// The user's profile image URL.
+  public let image: [UImage]?
+  
+  /// The user's Last.fm profile URL.
+  public let url: URL
+  
+  /// The user's country (if set).
+  public let country: String?
+  
+  /// The user's age (if set).
+  public let age: Int?
+  
+  /// The user's gender (if set).
+  public let gender: String?
+  
+  /// Whether the user is a subscriber.
+  public let subscriber: Bool?
+  
+  /// The number of tracks scrobbled by the user.
+  public let playcount: Double?
+  
+  /// The number of playlists created by the user.
+  public let playlists: Int?
+  
+  /// The number of registered users the user is following.
+  public let registered: UUserRegistered?
+}
+
+/// Represents user registration information.
+public struct UUserRegistered {
+  /// The Unix timestamp when the user registered.
+  public let unixtime: Int
+  
+  /// The formatted date when the user registered.
+  public let text: String
+}
+
+extension UUserRegistered: Codable {
+  enum CodingKeys: String, CodingKey {
+    case unixtime
+    case text = "#text"
+  }
+}
+
+extension UUserInfo {
+  enum MainKey: String, CodingKey {
+    case user
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case name
+    case realname
+    case image
+    case url
+    case country
+    case age
+    case gender
+    case subscriber
+    case playcount
+    case playlists
+    case registered
+  }
+}
+
+extension UUserInfo: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let userContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .user)
+    
+    self.name = try userContainer.decode(String.self, forKey: .name)
+    self.url = try userContainer.decode(URL.self, forKey: .url)
+    self.image = try userContainer.decodeIfPresent([UImage].self, forKey: .image)
+    self.realname = try userContainer.decodeIfPresent(String.self, forKey: .realname)
+    self.country = try userContainer.decodeIfPresent(String.self, forKey: .country)
+    self.gender = try userContainer.decodeIfPresent(String.self, forKey: .gender)
+    
+    // Parse numeric values
+    if let ageString = try userContainer.decodeIfPresent(String.self, forKey: .age), !ageString.isEmpty {
+      guard let ageValue = Int(ageString) else {
+        throw UmeroKitError.invalidDataFormat("Age is not a valid number for user '\(name)'")
+      }
+      self.age = ageValue
+    } else {
+      self.age = nil
+    }
+    
+    if let subscriberString = try userContainer.decodeIfPresent(String.self, forKey: .subscriber) {
+      self.subscriber = NSString(string: subscriberString).boolValue
+    } else {
+      self.subscriber = nil
+    }
+    
+    if let playcountString = try userContainer.decodeIfPresent(String.self, forKey: .playcount), !playcountString.isEmpty {
+      guard let playcountValue = Double(playcountString) else {
+        throw UmeroKitError.invalidDataFormat("Playcount is not a valid number for user '\(name)'")
+      }
+      self.playcount = playcountValue
+    } else {
+      self.playcount = nil
+    }
+    
+    if let playlistsString = try userContainer.decodeIfPresent(String.self, forKey: .playlists), !playlistsString.isEmpty {
+      guard let playlistsValue = Int(playlistsString) else {
+        throw UmeroKitError.invalidDataFormat("Playlists is not a valid number for user '\(name)'")
+      }
+      self.playlists = playlistsValue
+    } else {
+      self.playlists = nil
+    }
+    
+    self.registered = try userContainer.decodeIfPresent(UUserRegistered.self, forKey: .registered)
+  }
+}
+
+extension UUserInfo: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var userContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .user)
+    
+    try userContainer.encode(name, forKey: .name)
+    try userContainer.encode(url, forKey: .url)
+    try userContainer.encodeIfPresent(image, forKey: .image)
+    try userContainer.encodeIfPresent(realname, forKey: .realname)
+    try userContainer.encodeIfPresent(country, forKey: .country)
+    try userContainer.encodeIfPresent(gender, forKey: .gender)
+    
+    if let age {
+      try userContainer.encode(String(age), forKey: .age)
+    }
+    
+    if let subscriber {
+      try userContainer.encode(subscriber ? "1" : "0", forKey: .subscriber)
+    }
+    
+    if let playcount {
+      try userContainer.encode(String(playcount), forKey: .playcount)
+    }
+    
+    if let playlists {
+      try userContainer.encode(String(playlists), forKey: .playlists)
+    }
+    
+    try userContainer.encodeIfPresent(registered, forKey: .registered)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserInfo.swift
+++ b/Sources/UmeroKit/Models/UUserInfo.swift
@@ -101,11 +101,8 @@ extension UUserInfo: Decodable {
       self.age = nil
     }
     
-    if let subscriberString = try userContainer.decodeIfPresent(String.self, forKey: .subscriber) {
-      self.subscriber = NSString(string: subscriberString).boolValue
-    } else {
-      self.subscriber = nil
-    }
+    let subscriberString = try userContainer.decodeIfPresent(String.self, forKey: .subscriber)
+    self.subscriber = subscriberString.map { $0 == "1" }
     
     if let playcountString = try userContainer.decodeIfPresent(String.self, forKey: .playcount),
        !playcountString.isEmpty {

--- a/Sources/UmeroKit/Models/UUserLovedTracks.swift
+++ b/Sources/UmeroKit/Models/UUserLovedTracks.swift
@@ -59,11 +59,10 @@ extension UUserLovedTrack: Decodable {
     // Date parsing
     if let dateContainer = try? container.nestedContainer(keyedBy: DateKeys.self, forKey: .date) {
       let timestampString = try dateContainer.decode(String.self, forKey: .timestamp)
-      if let timestamp = Int(timestampString) {
-        self.date = Date(timeIntervalSince1970: TimeInterval(timestamp))
-      } else {
-        self.date = nil
+      guard let timestamp = Int(timestampString) else {
+        throw UmeroKitError.invalidDataFormat("Date timestamp for loved track '\(name)' is not a valid number.")
       }
+      self.date = Date(timeIntervalSince1970: TimeInterval(timestamp))
     } else {
       self.date = nil
     }
@@ -115,7 +114,7 @@ extension UUserLovedTracks: Decodable {
     if let singleTrack = try? tracksContainer.decode(UUserLovedTrack.self, forKey: .track) {
       self.tracks = [singleTrack]
     } else {
-      self.tracks = try tracksContainer.decode([UUserLovedTrack].self, forKey: .track)
+      self.tracks = try tracksContainer.decodeIfPresent([UUserLovedTrack].self, forKey: .track) ?? []
     }
     
     self.attributes = try tracksContainer.decode(UUserTopItemsAttributes.self, forKey: .attributes)

--- a/Sources/UmeroKit/Models/UUserLovedTracks.swift
+++ b/Sources/UmeroKit/Models/UUserLovedTracks.swift
@@ -1,0 +1,134 @@
+//
+//  UUserLovedTracks.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a loved track by a user.
+public struct UUserLovedTrack {
+  /// The track name.
+  public let name: String
+  
+  /// The artist information.
+  public let artist: UArtistInfo
+  
+  /// The track's MusicBrainz ID (if available).
+  public let mbid: UItemID?
+  
+  /// Last.fm page for the track.
+  public let url: URL
+  
+  /// Images associated with the track.
+  public let image: [UImage]
+  
+  /// The date when the track was loved.
+  public let date: Date?
+}
+
+extension UUserLovedTrack {
+  enum CodingKeys: String, CodingKey {
+    case name
+    case artist
+    case mbid
+    case url
+    case image
+    case date
+  }
+  
+  enum DateKeys: String, CodingKey {
+    case timestamp = "uts"
+    case text = "#text"
+  }
+}
+
+extension UUserLovedTrack: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    self.name = try container.decode(String.self, forKey: .name)
+    self.artist = try container.decode(UArtistInfo.self, forKey: .artist)
+    self.url = try container.decode(URL.self, forKey: .url)
+    self.image = try container.decode([UImage].self, forKey: .image)
+    
+    let mbidString = try container.decodeIfPresent(String.self, forKey: .mbid)
+    self.mbid = mbidString.map { UItemID(rawValue: $0) }
+    
+    // Date parsing
+    if let dateContainer = try? container.nestedContainer(keyedBy: DateKeys.self, forKey: .date) {
+      let timestampString = try dateContainer.decode(String.self, forKey: .timestamp)
+      if let timestamp = Int(timestampString) {
+        self.date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+      } else {
+        self.date = nil
+      }
+    } else {
+      self.date = nil
+    }
+  }
+}
+
+extension UUserLovedTrack: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(artist, forKey: .artist)
+    try container.encode(url, forKey: .url)
+    try container.encode(image, forKey: .image)
+    try container.encodeIfPresent(mbid?.rawValue, forKey: .mbid)
+    
+    if let date {
+      var dateContainer = container.nestedContainer(keyedBy: DateKeys.self, forKey: .date)
+      try dateContainer.encode(String(Int(date.timeIntervalSince1970)), forKey: .timestamp)
+    }
+  }
+}
+
+/// Represents loved tracks by a user.
+public struct UUserLovedTracks {
+  /// Collection of loved tracks.
+  public let tracks: [UUserLovedTrack]
+  
+  /// The attributes of the request like user, page, total pages, and total count.
+  public let attributes: UUserTopItemsAttributes
+}
+
+extension UUserLovedTracks {
+  enum MainKey: String, CodingKey {
+    case lovedtracks
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case track
+    case attributes = "@attr"
+  }
+}
+
+extension UUserLovedTracks: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let tracksContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .lovedtracks)
+    
+    // Handle both single track and array of tracks
+    if let singleTrack = try? tracksContainer.decode(UUserLovedTrack.self, forKey: .track) {
+      self.tracks = [singleTrack]
+    } else {
+      self.tracks = try tracksContainer.decode([UUserLovedTrack].self, forKey: .track)
+    }
+    
+    self.attributes = try tracksContainer.decode(UUserTopItemsAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserLovedTracks: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var tracksContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .lovedtracks)
+    
+    try tracksContainer.encode(tracks, forKey: .track)
+    try tracksContainer.encode(attributes, forKey: .attributes)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserLovedTracks.swift
+++ b/Sources/UmeroKit/Models/UUserLovedTracks.swift
@@ -131,4 +131,3 @@ extension UUserLovedTracks: Encodable {
     try tracksContainer.encode(attributes, forKey: .attributes)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserPersonalTags.swift
+++ b/Sources/UmeroKit/Models/UUserPersonalTags.swift
@@ -211,4 +211,3 @@ extension UUserPersonalTagsAttributes: Encodable {
     try container.encodeIfPresent(taggingtype, forKey: .taggingtype)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserPersonalTags.swift
+++ b/Sources/UmeroKit/Models/UUserPersonalTags.swift
@@ -1,0 +1,214 @@
+//
+//  UUserPersonalTags.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a personal tag applied by a user.
+public struct UUserPersonalTag {
+  /// The tag name.
+  public let name: String
+  
+  /// The number of times this tag has been used.
+  public let count: Int
+  
+  /// The URL for the tag.
+  public let url: URL
+  
+  /// The tagged item (artist, album, or track depending on taggingtype).
+  public let item: TaggedItem
+}
+
+/// Represents the tagged item (can be artist, album, or track).
+public enum TaggedItem {
+  case artist(UArtist)
+  case album(UAlbum)
+  case track(UTrack)
+}
+
+extension TaggedItem: Codable {
+  public init(from decoder: Decoder) throws {
+    // Try to decode as artist first
+    if let artist = try? UArtist(from: decoder) {
+      self = .artist(artist)
+      return
+    }
+    
+    // Try to decode as album
+    if let album = try? UAlbum(from: decoder) {
+      self = .album(album)
+      return
+    }
+    
+    // Try to decode as track
+    if let track = try? UTrack(from: decoder) {
+      self = .track(track)
+      return
+    }
+    
+    throw DecodingError.dataCorrupted(
+      DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Unable to decode tagged item")
+    )
+  }
+  
+  public func encode(to encoder: Encoder) throws {
+    switch self {
+    case .artist(let artist):
+      try artist.encode(to: encoder)
+    case .album(let album):
+      try album.encode(to: encoder)
+    case .track(let track):
+      try track.encode(to: encoder)
+    }
+  }
+}
+
+extension UUserPersonalTag {
+  enum CodingKeys: String, CodingKey {
+    case name
+    case count
+    case url
+  }
+}
+
+extension UUserPersonalTag: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    self.name = try container.decode(String.self, forKey: .name)
+    self.url = try container.decode(URL.self, forKey: .url)
+    
+    let countString = try container.decodeIfPresent(String.self, forKey: .count)
+    if let countString, !countString.isEmpty {
+      guard let countValue = Int(countString) else {
+        throw UmeroKitError.invalidDataFormat("Count is not a valid number for tag '\(name)'")
+      }
+      self.count = countValue
+    } else {
+      self.count = 0
+    }
+    
+    // Decode the tagged item (artist, album, or track)
+    self.item = try TaggedItem(from: decoder)
+  }
+}
+
+extension UUserPersonalTag: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(url, forKey: .url)
+    try container.encode(String(count), forKey: .count)
+    try item.encode(to: encoder)
+  }
+}
+
+/// Represents personal tags applied by a user.
+public struct UUserPersonalTags {
+  /// Collection of personal tags.
+  public let tags: [UUserPersonalTag]
+  
+  /// The attributes of the request like user, page, total pages, and total count.
+  public let attributes: UUserPersonalTagsAttributes
+}
+
+extension UUserPersonalTags {
+  enum MainKey: String, CodingKey {
+    case taggings
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case tag
+    case attributes = "@attr"
+  }
+}
+
+extension UUserPersonalTags: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let tagsContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .taggings)
+    
+    // Handle both single tag and array of tags
+    if let singleTag = try? tagsContainer.decode(UUserPersonalTag.self, forKey: .tag) {
+      self.tags = [singleTag]
+    } else {
+      self.tags = try tagsContainer.decode([UUserPersonalTag].self, forKey: .tag)
+    }
+    
+    self.attributes = try tagsContainer.decode(UUserPersonalTagsAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserPersonalTags: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var tagsContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .taggings)
+    
+    try tagsContainer.encode(tags, forKey: .tag)
+    try tagsContainer.encode(attributes, forKey: .attributes)
+  }
+}
+
+/// Represents attributes for user personal tags requests.
+public struct UUserPersonalTagsAttributes: Decodable {
+  /// The username.
+  public let user: String
+  
+  /// The current page of the results.
+  public let page: Int
+  
+  /// The number of items per page.
+  public let perPage: Int
+  
+  /// The total number of pages.
+  public let totalPages: Int
+  
+  /// The total number of items.
+  public let total: Int
+  
+  /// The type of tags (artist, album, or track).
+  public let taggingtype: String?
+}
+
+extension UUserPersonalTagsAttributes {
+  enum CodingKeys: CodingKey {
+    case user, page, perPage, totalPages, total, taggingtype
+  }
+  
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    let userName = try container.decode(String.self, forKey: .user)
+    
+    func decodeNumeric<T: LosslessStringConvertible>(_ key: CodingKeys) throws -> T {
+      let stringValue = try container.decode(String.self, forKey: key)
+      guard let value = T(stringValue) else {
+        throw UmeroKitError.invalidDataFormat("\(key.stringValue) is not a valid number for user '\(userName)'")
+      }
+      return value
+    }
+    
+    self.user = userName
+    self.page = try decodeNumeric(.page)
+    self.perPage = try decodeNumeric(.perPage)
+    self.totalPages = try decodeNumeric(.totalPages)
+    self.total = try decodeNumeric(.total)
+    self.taggingtype = try container.decodeIfPresent(String.self, forKey: .taggingtype)
+  }
+}
+
+extension UUserPersonalTagsAttributes: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(user, forKey: .user)
+    try container.encode(String(page), forKey: .page)
+    try container.encode(String(perPage), forKey: .perPage)
+    try container.encode(String(totalPages), forKey: .totalPages)
+    try container.encode(String(total), forKey: .total)
+    try container.encodeIfPresent(taggingtype, forKey: .taggingtype)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserRecentTracks.swift
+++ b/Sources/UmeroKit/Models/UUserRecentTracks.swift
@@ -18,7 +18,6 @@ public struct URecentTrackArtist {
 
 extension URecentTrackArtist {
   enum CodingKeys: String, CodingKey {
-    case name
     case mbid
     case text = "#text"
   }
@@ -28,12 +27,8 @@ extension URecentTrackArtist: Decodable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     
-    // Try to decode as #text first (API sometimes returns just #text)
-    if let text = try? container.decode(String.self, forKey: .text) {
-      self.name = text
-    } else {
-      self.name = try container.decode(String.self, forKey: .name)
-    }
+    // API returns artist name as #text, not name
+    self.name = try container.decode(String.self, forKey: .text)
     
     let mbid = try container.decodeIfPresent(String.self, forKey: .mbid)
     self.mbid = mbid.map { UItemID(rawValue: $0) }
@@ -43,7 +38,7 @@ extension URecentTrackArtist: Decodable {
 extension URecentTrackArtist: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(name, forKey: .name)
+    try container.encode(name, forKey: .text)
     try container.encodeIfPresent(mbid?.rawValue, forKey: .mbid)
   }
 }

--- a/Sources/UmeroKit/Models/UUserRecentTracks.swift
+++ b/Sources/UmeroKit/Models/UUserRecentTracks.swift
@@ -106,17 +106,16 @@ extension UUserRecentTrack: Decodable {
     // Date parsing
     if let dateContainer = try? container.nestedContainer(keyedBy: DateKeys.self, forKey: .date) {
       let timestampString = try dateContainer.decode(String.self, forKey: .timestamp)
-      if let timestamp = Int(timestampString) {
-        self.date = Date(timeIntervalSince1970: TimeInterval(timestamp))
-      } else {
-        self.date = nil
+      guard let timestamp = Int(timestampString) else {
+        throw UmeroKitError.invalidDataFormat("Date timestamp for recent track '\(name)' is not a valid number.")
       }
+      self.date = Date(timeIntervalSince1970: TimeInterval(timestamp))
     } else {
       self.date = nil
     }
     
     let lovedString = try container.decodeIfPresent(String.self, forKey: .loved)
-    self.loved = lovedString == "1"
+    self.loved = lovedString.map { $0 == "1" }
     
     self.album = try container.decodeIfPresent(String.self, forKey: .album)
     
@@ -130,7 +129,7 @@ extension UUserRecentTrack: Decodable {
     self.image = try container.decodeIfPresent([UImage].self, forKey: .image)
     
     let streamableString = try container.decodeIfPresent(String.self, forKey: .streamable)
-    self.streamable = streamableString == "1"
+    self.streamable = streamableString.map { $0 == "1" }
   }
 }
 

--- a/Sources/UmeroKit/Models/UUserRecentTracks.swift
+++ b/Sources/UmeroKit/Models/UUserRecentTracks.swift
@@ -225,4 +225,3 @@ extension UUserRecentTracksAttributes: Encodable {
     try container.encode(String(total), forKey: .total)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserRecentTracks.swift
+++ b/Sources/UmeroKit/Models/UUserRecentTracks.swift
@@ -1,0 +1,228 @@
+//
+//  UUserRecentTracks.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a recent track scrobbled by a user.
+public struct UUserRecentTrack {
+  /// The track name.
+  public let name: String
+  
+  /// The artist information.
+  public let artist: UArtistInfo
+  
+  /// The date and time when the track was scrobbled.
+  public let date: Date?
+  
+  /// Whether the user has loved this track.
+  public let loved: Bool?
+  
+  /// The album name (if available).
+  public let album: String?
+  
+  /// The album's MusicBrainz ID (if available).
+  public let albumMbid: UItemID?
+  
+  /// The track's MusicBrainz ID (if available).
+  public let mbid: UItemID?
+  
+  /// Last.fm page for the track.
+  public let url: URL?
+  
+  /// Images associated with the track.
+  public let image: [UImage]?
+  
+  /// Streamable flag (if available).
+  public let streamable: Bool?
+}
+
+extension UUserRecentTrack {
+  enum CodingKeys: String, CodingKey {
+    case name
+    case artist
+    case date
+    case loved
+    case album
+    case albumMbid = "album_mbid"
+    case mbid
+    case url
+    case image
+    case streamable
+  }
+  
+  enum DateKeys: String, CodingKey {
+    case timestamp = "uts"
+    case text = "#text"
+  }
+}
+
+extension UUserRecentTrack: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    self.name = try container.decode(String.self, forKey: .name)
+    self.artist = try container.decode(UArtistInfo.self, forKey: .artist)
+    
+    // Date parsing
+    if let dateContainer = try? container.nestedContainer(keyedBy: DateKeys.self, forKey: .date) {
+      let timestampString = try dateContainer.decode(String.self, forKey: .timestamp)
+      if let timestamp = Int(timestampString) {
+        self.date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+      } else {
+        self.date = nil
+      }
+    } else {
+      self.date = nil
+    }
+    
+    let lovedString = try container.decodeIfPresent(String.self, forKey: .loved)
+    self.loved = lovedString == "1"
+    
+    self.album = try container.decodeIfPresent(String.self, forKey: .album)
+    
+    let albumMbidString = try container.decodeIfPresent(String.self, forKey: .albumMbid)
+    self.albumMbid = albumMbidString.map { UItemID(rawValue: $0) }
+    
+    let mbidString = try container.decodeIfPresent(String.self, forKey: .mbid)
+    self.mbid = mbidString.map { UItemID(rawValue: $0) }
+    
+    self.url = try container.decodeIfPresent(URL.self, forKey: .url)
+    self.image = try container.decodeIfPresent([UImage].self, forKey: .image)
+    
+    let streamableString = try container.decodeIfPresent(String.self, forKey: .streamable)
+    self.streamable = streamableString == "1"
+  }
+}
+
+extension UUserRecentTrack: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(artist, forKey: .artist)
+    
+    if let date {
+      var dateContainer = container.nestedContainer(keyedBy: DateKeys.self, forKey: .date)
+      try dateContainer.encode(String(Int(date.timeIntervalSince1970)), forKey: .timestamp)
+    }
+    
+    if let loved {
+      try container.encode(loved ? "1" : "0", forKey: .loved)
+    }
+    
+    try container.encodeIfPresent(album, forKey: .album)
+    try container.encodeIfPresent(albumMbid?.rawValue, forKey: .albumMbid)
+    try container.encodeIfPresent(mbid?.rawValue, forKey: .mbid)
+    try container.encodeIfPresent(url, forKey: .url)
+    try container.encodeIfPresent(image, forKey: .image)
+    
+    if let streamable {
+      try container.encode(streamable ? "1" : "0", forKey: .streamable)
+    }
+  }
+}
+
+/// Represents recent tracks scrobbled by a user.
+public struct UUserRecentTracks {
+  /// Collection of recent tracks.
+  public let tracks: [UUserRecentTrack]
+  
+  /// The attributes of the request like user, page, total pages, and total count.
+  public let attributes: UUserRecentTracksAttributes
+}
+
+extension UUserRecentTracks {
+  enum MainKey: String, CodingKey {
+    case recenttracks
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case track
+    case attributes = "@attr"
+  }
+}
+
+extension UUserRecentTracks: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let tracksContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .recenttracks)
+    
+    // Handle both single track and array of tracks
+    if let singleTrack = try? tracksContainer.decode(UUserRecentTrack.self, forKey: .track) {
+      self.tracks = [singleTrack]
+    } else {
+      self.tracks = try tracksContainer.decode([UUserRecentTrack].self, forKey: .track)
+    }
+    
+    self.attributes = try tracksContainer.decode(UUserRecentTracksAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserRecentTracks: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var tracksContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .recenttracks)
+    
+    try tracksContainer.encode(tracks, forKey: .track)
+    try tracksContainer.encode(attributes, forKey: .attributes)
+  }
+}
+
+/// Represents attributes for user recent tracks requests.
+public struct UUserRecentTracksAttributes: Decodable {
+  /// The username.
+  public let user: String
+  
+  /// The current page of the results.
+  public let page: Int
+  
+  /// The number of items per page.
+  public let perPage: Int
+  
+  /// The total number of pages.
+  public let totalPages: Int
+  
+  /// The total number of items.
+  public let total: Int
+}
+
+extension UUserRecentTracksAttributes {
+  enum CodingKeys: CodingKey {
+    case user, page, perPage, totalPages, total
+  }
+  
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    let userName = try container.decode(String.self, forKey: .user)
+    
+    func decodeNumeric<T: LosslessStringConvertible>(_ key: CodingKeys) throws -> T {
+      let stringValue = try container.decode(String.self, forKey: key)
+      guard let value = T(stringValue) else {
+        throw UmeroKitError.invalidDataFormat("\(key.stringValue) is not a valid number for user '\(userName)'")
+      }
+      return value
+    }
+    
+    self.user = userName
+    self.page = try decodeNumeric(.page)
+    self.perPage = try decodeNumeric(.perPage)
+    self.totalPages = try decodeNumeric(.totalPages)
+    self.total = try decodeNumeric(.total)
+  }
+}
+
+extension UUserRecentTracksAttributes: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(user, forKey: .user)
+    try container.encode(String(page), forKey: .page)
+    try container.encode(String(perPage), forKey: .perPage)
+    try container.encode(String(totalPages), forKey: .totalPages)
+    try container.encode(String(total), forKey: .total)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserTags.swift
+++ b/Sources/UmeroKit/Models/UUserTags.swift
@@ -44,4 +44,3 @@ extension UUserTags: Encodable {
     try container.encode(tags, forKey: .tags)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserTags.swift
+++ b/Sources/UmeroKit/Models/UUserTags.swift
@@ -1,0 +1,47 @@
+//
+//  UUserTags.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents tags applied by a user on Last.fm.
+public struct UUserTags {
+  /// The tags applied by the user.
+  public let tags: UTags
+}
+
+extension UUserTags {
+  enum CodingKeys: String, CodingKey {
+    case tags
+  }
+}
+
+extension UUserTags: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    enum TagsContainerKeys: String, CodingKey {
+      case tag
+      // The "@attr" key is intentionally ignored as it's not used.
+    }
+    
+    if container.contains(.tags) {
+      let tagsContainer = try container.nestedContainer(keyedBy: TagsContainerKeys.self, forKey: .tags)
+      let tagArray = try tagsContainer.decodeIfPresent([UTag].self, forKey: .tag) ?? []
+      self.tags = UTags(tag: tagArray)
+    } else {
+      self.tags = UTags(tag: [])
+    }
+  }
+}
+
+extension UUserTags: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(tags, forKey: .tags)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserTopAlbums.swift
+++ b/Sources/UmeroKit/Models/UUserTopAlbums.swift
@@ -1,0 +1,109 @@
+//
+//  UUserTopAlbums.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a lightweight album from user top albums endpoint.
+public struct UUserTopAlbum {
+  /// Name of the album.
+  public let name: String
+  
+  /// Artist information.
+  public let artist: UArtistInfo
+  
+  /// MusicBrainz ID of the album (if available).
+  public let mbid: UItemID?
+  
+  /// Number of times the album has been played by the user.
+  public let playcount: Double
+  
+  /// Last.fm page for the album.
+  public let url: URL
+  
+  /// Images associated with the album.
+  public let image: [UImage]
+}
+
+extension UUserTopAlbum: Decodable {
+  enum CodingKeys: String, CodingKey {
+    case name, artist, mbid, playcount, url, image
+  }
+  
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.name = try container.decode(String.self, forKey: .name)
+    self.artist = try container.decode(UArtistInfo.self, forKey: .artist)
+    self.url = try container.decode(URL.self, forKey: .url)
+    self.image = try container.decode([UImage].self, forKey: .image)
+    
+    let mbid = try container.decodeIfPresent(String.self, forKey: .mbid)
+    self.mbid = mbid.map { UItemID(rawValue: $0) }
+    
+    let playcountString = try container.decodeIfPresent(String.self, forKey: .playcount)
+    if let playcountString, !playcountString.isEmpty {
+      guard let playcount = Double(playcountString) else {
+        throw UmeroKitError.invalidDataFormat("Playcount is not a valid number for album '\(name)'")
+      }
+      self.playcount = playcount
+    } else {
+      self.playcount = 0
+    }
+  }
+}
+
+extension UUserTopAlbum: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(artist, forKey: .artist)
+    try container.encode(url, forKey: .url)
+    try container.encode(image, forKey: .image)
+    try container.encodeIfPresent(mbid?.rawValue, forKey: .mbid)
+    try container.encode(String(playcount), forKey: .playcount)
+  }
+}
+
+/// Represents the top albums for a user on Last.fm.
+public struct UUserTopAlbums {
+  /// Collection of `UUserTopAlbum` representing the top albums for the user.
+  public let albums: [UUserTopAlbum]
+
+  /// The attributes of the request like user, page, total pages, and total count.
+  public let attributes: UUserTopItemsAttributes
+}
+
+extension UUserTopAlbums {
+  enum MainKey: String, CodingKey {
+    case topalbums
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case album
+    case attributes = "@attr"
+  }
+}
+
+extension UUserTopAlbums: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let albumsContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .topalbums)
+
+    self.albums = try albumsContainer.decode([UUserTopAlbum].self, forKey: .album)
+    self.attributes = try albumsContainer.decode(UUserTopItemsAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserTopAlbums: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var albumsContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .topalbums)
+    
+    try albumsContainer.encode(albums, forKey: .album)
+    try albumsContainer.encode(attributes, forKey: .attributes)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserTopAlbums.swift
+++ b/Sources/UmeroKit/Models/UUserTopAlbums.swift
@@ -106,4 +106,3 @@ extension UUserTopAlbums: Encodable {
     try albumsContainer.encode(attributes, forKey: .attributes)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserTopAlbums.swift
+++ b/Sources/UmeroKit/Models/UUserTopAlbums.swift
@@ -92,7 +92,12 @@ extension UUserTopAlbums: Decodable {
     let container = try decoder.container(keyedBy: MainKey.self)
     let albumsContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .topalbums)
 
-    self.albums = try albumsContainer.decode([UUserTopAlbum].self, forKey: .album)
+    // Handle both single album and array of albums
+    if let singleAlbum = try? albumsContainer.decode(UUserTopAlbum.self, forKey: .album) {
+      self.albums = [singleAlbum]
+    } else {
+      self.albums = try albumsContainer.decodeIfPresent([UUserTopAlbum].self, forKey: .album) ?? []
+    }
     self.attributes = try albumsContainer.decode(UUserTopItemsAttributes.self, forKey: .attributes)
   }
 }

--- a/Sources/UmeroKit/Models/UUserTopArtists.swift
+++ b/Sources/UmeroKit/Models/UUserTopArtists.swift
@@ -1,0 +1,110 @@
+//
+//  UUserTopArtists.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents the top artists for a user on Last.fm.
+public struct UUserTopArtists {
+  /// Collection of `UArtist` representing the top artists for the user.
+  public let artists: [UArtist]
+
+  /// The attributes of the request like user, page, total pages, and total count.
+  public let attributes: UUserTopItemsAttributes
+}
+
+extension UUserTopArtists {
+  enum MainKey: String, CodingKey {
+    case topartists
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case artist
+    case attributes = "@attr"
+  }
+}
+
+extension UUserTopArtists: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let artistsContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .topartists)
+
+    self.artists = try artistsContainer.decode([UArtist].self, forKey: .artist)
+    self.attributes = try artistsContainer.decode(UUserTopItemsAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserTopArtists: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var artistsContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .topartists)
+    
+    try artistsContainer.encode(artists, forKey: .artist)
+    try artistsContainer.encode(attributes, forKey: .attributes)
+  }
+}
+
+/// Represents attributes for user top items requests.
+public struct UUserTopItemsAttributes: Decodable {
+  /// The username.
+  public let user: String
+
+  /// The current page of the results.
+  public let page: Int
+
+  /// The number of items per page.
+  public let perPage: Int
+
+  /// The total number of pages.
+  public let totalPages: Int
+
+  /// The total number of items.
+  public let total: Int
+  
+  /// The time period (optional).
+  public let period: String?
+}
+
+extension UUserTopItemsAttributes {
+  enum CodingKeys: CodingKey {
+    case user, page, perPage, totalPages, total, period
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    let userName = try container.decode(String.self, forKey: .user)
+
+    // Helper function to decode numeric values from strings
+    func decodeNumeric<T: LosslessStringConvertible>(_ key: CodingKeys) throws -> T {
+      let stringValue = try container.decode(String.self, forKey: key)
+      guard let value = T(stringValue) else {
+        throw UmeroKitError.invalidDataFormat("\(key.stringValue) is not a valid number for user '\(userName)'")
+      }
+      return value
+    }
+
+    self.user = userName
+    self.page = try decodeNumeric(.page)
+    self.perPage = try decodeNumeric(.perPage)
+    self.totalPages = try decodeNumeric(.totalPages)
+    self.total = try decodeNumeric(.total)
+    self.period = try container.decodeIfPresent(String.self, forKey: .period)
+  }
+}
+
+extension UUserTopItemsAttributes: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(user, forKey: .user)
+    try container.encode(String(page), forKey: .page)
+    try container.encode(String(perPage), forKey: .perPage)
+    try container.encode(String(totalPages), forKey: .totalPages)
+    try container.encode(String(total), forKey: .total)
+    try container.encodeIfPresent(period, forKey: .period)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserTopArtists.swift
+++ b/Sources/UmeroKit/Models/UUserTopArtists.swift
@@ -107,4 +107,3 @@ extension UUserTopItemsAttributes: Encodable {
     try container.encodeIfPresent(period, forKey: .period)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserTopArtists.swift
+++ b/Sources/UmeroKit/Models/UUserTopArtists.swift
@@ -32,7 +32,12 @@ extension UUserTopArtists: Decodable {
     let container = try decoder.container(keyedBy: MainKey.self)
     let artistsContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .topartists)
 
-    self.artists = try artistsContainer.decode([UArtist].self, forKey: .artist)
+    // Handle both single artist and array of artists
+    if let singleArtist = try? artistsContainer.decode(UArtist.self, forKey: .artist) {
+      self.artists = [singleArtist]
+    } else {
+      self.artists = try artistsContainer.decodeIfPresent([UArtist].self, forKey: .artist) ?? []
+    }
     self.attributes = try artistsContainer.decode(UUserTopItemsAttributes.self, forKey: .attributes)
   }
 }

--- a/Sources/UmeroKit/Models/UUserTopTags.swift
+++ b/Sources/UmeroKit/Models/UUserTopTags.swift
@@ -10,4 +10,3 @@ import Foundation
 /// Represents the top tags for a user on Last.fm.
 /// Reuses UTopTags structure as the API response format is identical.
 public typealias UUserTopTags = UTopTags
-

--- a/Sources/UmeroKit/Models/UUserTopTags.swift
+++ b/Sources/UmeroKit/Models/UUserTopTags.swift
@@ -1,0 +1,13 @@
+//
+//  UUserTopTags.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents the top tags for a user on Last.fm.
+/// Reuses UTopTags structure as the API response format is identical.
+public typealias UUserTopTags = UTopTags
+

--- a/Sources/UmeroKit/Models/UUserTopTracks.swift
+++ b/Sources/UmeroKit/Models/UUserTopTracks.swift
@@ -99,7 +99,12 @@ extension UUserTopTracks: Decodable {
     let container = try decoder.container(keyedBy: MainKey.self)
     let tracksContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .toptracks)
 
-    self.tracks = try tracksContainer.decode([UUserTopTrack].self, forKey: .track)
+    // Handle both single track and array of tracks
+    if let singleTrack = try? tracksContainer.decode(UUserTopTrack.self, forKey: .track) {
+      self.tracks = [singleTrack]
+    } else {
+      self.tracks = try tracksContainer.decodeIfPresent([UUserTopTrack].self, forKey: .track) ?? []
+    }
     self.attributes = try tracksContainer.decode(UUserTopItemsAttributes.self, forKey: .attributes)
   }
 }

--- a/Sources/UmeroKit/Models/UUserTopTracks.swift
+++ b/Sources/UmeroKit/Models/UUserTopTracks.swift
@@ -113,4 +113,3 @@ extension UUserTopTracks: Encodable {
     try tracksContainer.encode(attributes, forKey: .attributes)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserTopTracks.swift
+++ b/Sources/UmeroKit/Models/UUserTopTracks.swift
@@ -1,0 +1,116 @@
+//
+//  UUserTopTracks.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a lightweight track from user top tracks endpoint.
+public struct UUserTopTrack {
+  /// Name of the track.
+  public let name: String
+  
+  /// Artist information.
+  public let artist: UArtistInfo
+  
+  /// MusicBrainz ID of the track (if available).
+  public let mbid: UItemID?
+  
+  /// Number of times the track has been played by the user.
+  public let playcount: Double
+  
+  /// Last.fm page for the track.
+  public let url: URL
+  
+  /// Streamable flag indicating if the track can be streamed.
+  public let streamable: Bool
+  
+  /// Images associated with the track.
+  public let image: [UImage]
+}
+
+extension UUserTopTrack: Decodable {
+  enum CodingKeys: String, CodingKey {
+    case name, artist, mbid, playcount, url, streamable, image
+  }
+  
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.name = try container.decode(String.self, forKey: .name)
+    self.artist = try container.decode(UArtistInfo.self, forKey: .artist)
+    self.url = try container.decode(URL.self, forKey: .url)
+    self.image = try container.decode([UImage].self, forKey: .image)
+    
+    let mbid = try container.decodeIfPresent(String.self, forKey: .mbid)
+    self.mbid = mbid.map { UItemID(rawValue: $0) }
+    
+    let streamableString = try container.decodeIfPresent(String.self, forKey: .streamable)
+    self.streamable = streamableString == "1"
+    
+    let playcountString = try container.decodeIfPresent(String.self, forKey: .playcount)
+    if let playcountString, !playcountString.isEmpty {
+      guard let playcount = Double(playcountString) else {
+        throw UmeroKitError.invalidDataFormat("Playcount is not a valid number for track '\(name)'")
+      }
+      self.playcount = playcount
+    } else {
+      self.playcount = 0
+    }
+  }
+}
+
+extension UUserTopTrack: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(artist, forKey: .artist)
+    try container.encode(url, forKey: .url)
+    try container.encode(image, forKey: .image)
+    try container.encodeIfPresent(mbid?.rawValue, forKey: .mbid)
+    try container.encode(String(playcount), forKey: .playcount)
+    try container.encode(streamable ? "1" : "0", forKey: .streamable)
+  }
+}
+
+/// Represents the top tracks for a user on Last.fm.
+public struct UUserTopTracks {
+  /// Collection of `UUserTopTrack` representing the top tracks for the user.
+  public let tracks: [UUserTopTrack]
+
+  /// The attributes of the request like user, page, total pages, and total count.
+  public let attributes: UUserTopItemsAttributes
+}
+
+extension UUserTopTracks {
+  enum MainKey: String, CodingKey {
+    case toptracks
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case track
+    case attributes = "@attr"
+  }
+}
+
+extension UUserTopTracks: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let tracksContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .toptracks)
+
+    self.tracks = try tracksContainer.decode([UUserTopTrack].self, forKey: .track)
+    self.attributes = try tracksContainer.decode(UUserTopItemsAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserTopTracks: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var tracksContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .toptracks)
+    
+    try tracksContainer.encode(tracks, forKey: .track)
+    try tracksContainer.encode(attributes, forKey: .attributes)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserWeeklyAlbumChart.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyAlbumChart.swift
@@ -1,0 +1,191 @@
+//
+//  UUserWeeklyAlbumChart.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a weekly album chart entry for a user.
+public struct UUserWeeklyAlbumChartItem {
+  /// The album name.
+  public let name: String
+  
+  /// The artist information.
+  public let artist: UArtistInfo
+  
+  /// The album's MusicBrainz ID (if available).
+  public let mbid: UItemID?
+  
+  /// The number of plays during the chart period.
+  public let playcount: Double
+  
+  /// Last.fm page for the album.
+  public let url: URL
+  
+  /// Images associated with the album.
+  public let image: [UImage]
+  
+  /// The rank in the chart.
+  public let rank: Int
+}
+
+extension UUserWeeklyAlbumChartItem {
+  enum CodingKeys: String, CodingKey {
+    case name
+    case artist
+    case mbid
+    case playcount
+    case url
+    case image
+    case rank = "@attr"
+  }
+  
+  enum RankKeys: String, CodingKey {
+    case rank
+  }
+}
+
+extension UUserWeeklyAlbumChartItem: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    self.name = try container.decode(String.self, forKey: .name)
+    self.artist = try container.decode(UArtistInfo.self, forKey: .artist)
+    self.url = try container.decode(URL.self, forKey: .url)
+    self.image = try container.decode([UImage].self, forKey: .image)
+    
+    let mbidString = try container.decodeIfPresent(String.self, forKey: .mbid)
+    self.mbid = mbidString.map { UItemID(rawValue: $0) }
+    
+    let playcountString = try container.decodeIfPresent(String.self, forKey: .playcount)
+    if let playcountString, !playcountString.isEmpty {
+      guard let playcount = Double(playcountString) else {
+        throw UmeroKitError.invalidDataFormat("Playcount is not a valid number for album '\(name)'")
+      }
+      self.playcount = playcount
+    } else {
+      self.playcount = 0
+    }
+    
+    // Extract rank from @attr
+    let rankContainer = try container.nestedContainer(keyedBy: RankKeys.self, forKey: .rank)
+    let rankString = try rankContainer.decode(String.self, forKey: .rank)
+    guard let rankValue = Int(rankString) else {
+      throw UmeroKitError.invalidDataFormat("Rank is not a valid number for album '\(name)'")
+    }
+    self.rank = rankValue
+  }
+}
+
+extension UUserWeeklyAlbumChartItem: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(artist, forKey: .artist)
+    try container.encode(url, forKey: .url)
+    try container.encode(image, forKey: .image)
+    try container.encodeIfPresent(mbid?.rawValue, forKey: .mbid)
+    try container.encode(String(playcount), forKey: .playcount)
+    
+    var rankContainer = container.nestedContainer(keyedBy: RankKeys.self, forKey: .rank)
+    try rankContainer.encode(String(rank), forKey: .rank)
+  }
+}
+
+/// Represents a weekly album chart for a user.
+public struct UUserWeeklyAlbumChart {
+  /// Collection of weekly album chart entries.
+  public let albums: [UUserWeeklyAlbumChartItem]
+  
+  /// The attributes of the request like user, from, and to dates.
+  public let attributes: UUserWeeklyChartAttributes
+}
+
+extension UUserWeeklyAlbumChart {
+  enum MainKey: String, CodingKey {
+    case weeklyalbumchart
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case album
+    case attributes = "@attr"
+  }
+}
+
+extension UUserWeeklyAlbumChart: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let chartContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .weeklyalbumchart)
+    
+    // Handle both single album and array of albums
+    if let singleAlbum = try? chartContainer.decode(UUserWeeklyAlbumChartItem.self, forKey: .album) {
+      self.albums = [singleAlbum]
+    } else {
+      self.albums = try chartContainer.decode([UUserWeeklyAlbumChartItem].self, forKey: .album)
+    }
+    
+    self.attributes = try chartContainer.decode(UUserWeeklyChartAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserWeeklyAlbumChart: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var chartContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .weeklyalbumchart)
+    
+    try chartContainer.encode(albums, forKey: .album)
+    try chartContainer.encode(attributes, forKey: .attributes)
+  }
+}
+
+/// Represents attributes for user weekly chart requests.
+public struct UUserWeeklyChartAttributes: Decodable {
+  /// The username.
+  public let user: String
+  
+  /// The start date of the chart period.
+  public let from: Date
+  
+  /// The end date of the chart period.
+  public let to: Date
+}
+
+extension UUserWeeklyChartAttributes {
+  enum CodingKeys: String, CodingKey {
+    case user
+    case from
+    case to
+  }
+  
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    self.user = try container.decode(String.self, forKey: .user)
+    
+    let fromString = try container.decode(String.self, forKey: .from)
+    let toString = try container.decode(String.self, forKey: .to)
+    
+    guard let fromTimestamp = Int(fromString) else {
+      throw UmeroKitError.invalidDataFormat("From timestamp is not valid for user '\(user)'")
+    }
+    
+    guard let toTimestamp = Int(toString) else {
+      throw UmeroKitError.invalidDataFormat("To timestamp is not valid for user '\(user)'")
+    }
+    
+    self.from = Date(timeIntervalSince1970: TimeInterval(fromTimestamp))
+    self.to = Date(timeIntervalSince1970: TimeInterval(toTimestamp))
+  }
+}
+
+extension UUserWeeklyChartAttributes: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(user, forKey: .user)
+    try container.encode(String(Int(from.timeIntervalSince1970)), forKey: .from)
+    try container.encode(String(Int(to.timeIntervalSince1970)), forKey: .to)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserWeeklyAlbumChart.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyAlbumChart.swift
@@ -123,7 +123,7 @@ extension UUserWeeklyAlbumChart: Decodable {
     if let singleAlbum = try? chartContainer.decode(UUserWeeklyAlbumChartItem.self, forKey: .album) {
       self.albums = [singleAlbum]
     } else {
-      self.albums = try chartContainer.decode([UUserWeeklyAlbumChartItem].self, forKey: .album)
+      self.albums = try chartContainer.decodeIfPresent([UUserWeeklyAlbumChartItem].self, forKey: .album) ?? []
     }
     
     self.attributes = try chartContainer.decode(UUserWeeklyChartAttributes.self, forKey: .attributes)

--- a/Sources/UmeroKit/Models/UUserWeeklyAlbumChart.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyAlbumChart.swift
@@ -188,4 +188,3 @@ extension UUserWeeklyChartAttributes: Encodable {
     try container.encode(String(Int(to.timeIntervalSince1970)), forKey: .to)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserWeeklyArtistChart.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyArtistChart.swift
@@ -133,4 +133,3 @@ extension UUserWeeklyArtistChart: Encodable {
     try chartContainer.encode(attributes, forKey: .attributes)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserWeeklyArtistChart.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyArtistChart.swift
@@ -1,0 +1,136 @@
+//
+//  UUserWeeklyArtistChart.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a weekly artist chart entry for a user.
+public struct UUserWeeklyArtistChartItem {
+  /// The artist name.
+  public let name: String
+  
+  /// The artist's MusicBrainz ID (if available).
+  public let mbid: UItemID?
+  
+  /// The number of plays during the chart period.
+  public let playcount: Double
+  
+  /// Last.fm page for the artist.
+  public let url: URL
+  
+  /// Images associated with the artist.
+  public let image: [UImage]
+  
+  /// The rank in the chart.
+  public let rank: Int
+}
+
+extension UUserWeeklyArtistChartItem {
+  enum CodingKeys: String, CodingKey {
+    case name
+    case mbid
+    case playcount
+    case url
+    case image
+    case rank = "@attr"
+  }
+  
+  enum RankKeys: String, CodingKey {
+    case rank
+  }
+}
+
+extension UUserWeeklyArtistChartItem: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    self.name = try container.decode(String.self, forKey: .name)
+    self.url = try container.decode(URL.self, forKey: .url)
+    self.image = try container.decode([UImage].self, forKey: .image)
+    
+    let mbidString = try container.decodeIfPresent(String.self, forKey: .mbid)
+    self.mbid = mbidString.map { UItemID(rawValue: $0) }
+    
+    let playcountString = try container.decodeIfPresent(String.self, forKey: .playcount)
+    if let playcountString, !playcountString.isEmpty {
+      guard let playcount = Double(playcountString) else {
+        throw UmeroKitError.invalidDataFormat("Playcount is not a valid number for artist '\(name)'")
+      }
+      self.playcount = playcount
+    } else {
+      self.playcount = 0
+    }
+    
+    // Extract rank from @attr
+    let rankContainer = try container.nestedContainer(keyedBy: RankKeys.self, forKey: .rank)
+    let rankString = try rankContainer.decode(String.self, forKey: .rank)
+    guard let rankValue = Int(rankString) else {
+      throw UmeroKitError.invalidDataFormat("Rank is not a valid number for artist '\(name)'")
+    }
+    self.rank = rankValue
+  }
+}
+
+extension UUserWeeklyArtistChartItem: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(url, forKey: .url)
+    try container.encode(image, forKey: .image)
+    try container.encodeIfPresent(mbid?.rawValue, forKey: .mbid)
+    try container.encode(String(playcount), forKey: .playcount)
+    
+    var rankContainer = container.nestedContainer(keyedBy: RankKeys.self, forKey: .rank)
+    try rankContainer.encode(String(rank), forKey: .rank)
+  }
+}
+
+/// Represents a weekly artist chart for a user.
+public struct UUserWeeklyArtistChart {
+  /// Collection of weekly artist chart entries.
+  public let artists: [UUserWeeklyArtistChartItem]
+  
+  /// The attributes of the request like user, from, and to dates.
+  public let attributes: UUserWeeklyChartAttributes
+}
+
+extension UUserWeeklyArtistChart {
+  enum MainKey: String, CodingKey {
+    case weeklyartistchart
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case artist
+    case attributes = "@attr"
+  }
+}
+
+extension UUserWeeklyArtistChart: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let chartContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .weeklyartistchart)
+    
+    // Handle both single artist and array of artists
+    if let singleArtist = try? chartContainer.decode(UUserWeeklyArtistChartItem.self, forKey: .artist) {
+      self.artists = [singleArtist]
+    } else {
+      self.artists = try chartContainer.decode([UUserWeeklyArtistChartItem].self, forKey: .artist)
+    }
+    
+    self.attributes = try chartContainer.decode(UUserWeeklyChartAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserWeeklyArtistChart: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var chartContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .weeklyartistchart)
+    
+    try chartContainer.encode(artists, forKey: .artist)
+    try chartContainer.encode(attributes, forKey: .attributes)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserWeeklyArtistChart.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyArtistChart.swift
@@ -117,7 +117,7 @@ extension UUserWeeklyArtistChart: Decodable {
     if let singleArtist = try? chartContainer.decode(UUserWeeklyArtistChartItem.self, forKey: .artist) {
       self.artists = [singleArtist]
     } else {
-      self.artists = try chartContainer.decode([UUserWeeklyArtistChartItem].self, forKey: .artist)
+      self.artists = try chartContainer.decodeIfPresent([UUserWeeklyArtistChartItem].self, forKey: .artist) ?? []
     }
     
     self.attributes = try chartContainer.decode(UUserWeeklyChartAttributes.self, forKey: .attributes)

--- a/Sources/UmeroKit/Models/UUserWeeklyChartList.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyChartList.swift
@@ -68,7 +68,12 @@ extension UUserWeeklyChartList: Decodable {
     let container = try decoder.container(keyedBy: MainKey.self)
     let chartListContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .weeklychartlist)
 
-    self.chartList = try chartListContainer.decode([UUserWeeklyChartListItem].self, forKey: .chart)
+    // Handle both single chart and array of charts
+    if let singleChart = try? chartListContainer.decode(UUserWeeklyChartListItem.self, forKey: .chart) {
+      self.chartList = [singleChart]
+    } else {
+      self.chartList = try chartListContainer.decodeIfPresent([UUserWeeklyChartListItem].self, forKey: .chart) ?? []
+    }
   }
 }
 

--- a/Sources/UmeroKit/Models/UUserWeeklyChartList.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyChartList.swift
@@ -79,4 +79,3 @@ extension UUserWeeklyChartList: Encodable {
     try chartListContainer.encode(chartList, forKey: .chart)
   }
 }
-

--- a/Sources/UmeroKit/Models/UUserWeeklyChartList.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyChartList.swift
@@ -1,0 +1,82 @@
+//
+//  UUserWeeklyChartList.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a weekly chart list entry for a user.
+public struct UUserWeeklyChartListItem: Codable {
+  /// The start date of the chart period.
+  public let from: Date
+
+  /// The end date of the chart period.
+  public let to: Date
+}
+
+extension UUserWeeklyChartListItem {
+  enum CodingKeys: String, CodingKey {
+    case from, to
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    // Decode as String first (Last.fm returns timestamps as strings), then convert to Int
+    let fromString = try container.decode(String.self, forKey: .from)
+    let toString = try container.decode(String.self, forKey: .to)
+    
+    guard let fromTimestamp = Int(fromString) else {
+      throw DecodingError.dataCorruptedError(forKey: .from, in: container, debugDescription: "Invalid timestamp format")
+    }
+    
+    guard let toTimestamp = Int(toString) else {
+      throw DecodingError.dataCorruptedError(forKey: .to, in: container, debugDescription: "Invalid timestamp format")
+    }
+
+    self.from = Date(timeIntervalSince1970: TimeInterval(fromTimestamp))
+    self.to = Date(timeIntervalSince1970: TimeInterval(toTimestamp))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(Int(from.timeIntervalSince1970), forKey: .from)
+    try container.encode(Int(to.timeIntervalSince1970), forKey: .to)
+  }
+}
+
+/// Represents the weekly chart list for a user.
+public struct UUserWeeklyChartList {
+  /// Collection of weekly chart list entries.
+  public let chartList: [UUserWeeklyChartListItem]
+}
+
+extension UUserWeeklyChartList {
+  enum MainKey: String, CodingKey {
+    case weeklychartlist
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case chart
+  }
+}
+
+extension UUserWeeklyChartList: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let chartListContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .weeklychartlist)
+
+    self.chartList = try chartListContainer.decode([UUserWeeklyChartListItem].self, forKey: .chart)
+  }
+}
+
+extension UUserWeeklyChartList: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var chartListContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .weeklychartlist)
+    try chartListContainer.encode(chartList, forKey: .chart)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserWeeklyTrackChart.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyTrackChart.swift
@@ -123,7 +123,7 @@ extension UUserWeeklyTrackChart: Decodable {
     if let singleTrack = try? chartContainer.decode(UUserWeeklyTrackChartItem.self, forKey: .track) {
       self.tracks = [singleTrack]
     } else {
-      self.tracks = try chartContainer.decode([UUserWeeklyTrackChartItem].self, forKey: .track)
+      self.tracks = try chartContainer.decodeIfPresent([UUserWeeklyTrackChartItem].self, forKey: .track) ?? []
     }
     
     self.attributes = try chartContainer.decode(UUserWeeklyChartAttributes.self, forKey: .attributes)

--- a/Sources/UmeroKit/Models/UUserWeeklyTrackChart.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyTrackChart.swift
@@ -1,0 +1,142 @@
+//
+//  UUserWeeklyTrackChart.swift
+//  UmeroKit
+//
+//  Created by Rudrank Riyam on 27/12/22.
+//
+
+import Foundation
+
+/// Represents a weekly track chart entry for a user.
+public struct UUserWeeklyTrackChartItem {
+  /// The track name.
+  public let name: String
+  
+  /// The artist information.
+  public let artist: UArtistInfo
+  
+  /// The track's MusicBrainz ID (if available).
+  public let mbid: UItemID?
+  
+  /// The number of plays during the chart period.
+  public let playcount: Double
+  
+  /// Last.fm page for the track.
+  public let url: URL
+  
+  /// Images associated with the track.
+  public let image: [UImage]
+  
+  /// The rank in the chart.
+  public let rank: Int
+}
+
+extension UUserWeeklyTrackChartItem {
+  enum CodingKeys: String, CodingKey {
+    case name
+    case artist
+    case mbid
+    case playcount
+    case url
+    case image
+    case rank = "@attr"
+  }
+  
+  enum RankKeys: String, CodingKey {
+    case rank
+  }
+}
+
+extension UUserWeeklyTrackChartItem: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    
+    self.name = try container.decode(String.self, forKey: .name)
+    self.artist = try container.decode(UArtistInfo.self, forKey: .artist)
+    self.url = try container.decode(URL.self, forKey: .url)
+    self.image = try container.decode([UImage].self, forKey: .image)
+    
+    let mbidString = try container.decodeIfPresent(String.self, forKey: .mbid)
+    self.mbid = mbidString.map { UItemID(rawValue: $0) }
+    
+    let playcountString = try container.decodeIfPresent(String.self, forKey: .playcount)
+    if let playcountString, !playcountString.isEmpty {
+      guard let playcount = Double(playcountString) else {
+        throw UmeroKitError.invalidDataFormat("Playcount is not a valid number for track '\(name)'")
+      }
+      self.playcount = playcount
+    } else {
+      self.playcount = 0
+    }
+    
+    // Extract rank from @attr
+    let rankContainer = try container.nestedContainer(keyedBy: RankKeys.self, forKey: .rank)
+    let rankString = try rankContainer.decode(String.self, forKey: .rank)
+    guard let rankValue = Int(rankString) else {
+      throw UmeroKitError.invalidDataFormat("Rank is not a valid number for track '\(name)'")
+    }
+    self.rank = rankValue
+  }
+}
+
+extension UUserWeeklyTrackChartItem: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(artist, forKey: .artist)
+    try container.encode(url, forKey: .url)
+    try container.encode(image, forKey: .image)
+    try container.encodeIfPresent(mbid?.rawValue, forKey: .mbid)
+    try container.encode(String(playcount), forKey: .playcount)
+    
+    var rankContainer = container.nestedContainer(keyedBy: RankKeys.self, forKey: .rank)
+    try rankContainer.encode(String(rank), forKey: .rank)
+  }
+}
+
+/// Represents a weekly track chart for a user.
+public struct UUserWeeklyTrackChart {
+  /// Collection of weekly track chart entries.
+  public let tracks: [UUserWeeklyTrackChartItem]
+  
+  /// The attributes of the request like user, from, and to dates.
+  public let attributes: UUserWeeklyChartAttributes
+}
+
+extension UUserWeeklyTrackChart {
+  enum MainKey: String, CodingKey {
+    case weeklytrackchart
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case track
+    case attributes = "@attr"
+  }
+}
+
+extension UUserWeeklyTrackChart: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: MainKey.self)
+    let chartContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .weeklytrackchart)
+    
+    // Handle both single track and array of tracks
+    if let singleTrack = try? chartContainer.decode(UUserWeeklyTrackChartItem.self, forKey: .track) {
+      self.tracks = [singleTrack]
+    } else {
+      self.tracks = try chartContainer.decode([UUserWeeklyTrackChartItem].self, forKey: .track)
+    }
+    
+    self.attributes = try chartContainer.decode(UUserWeeklyChartAttributes.self, forKey: .attributes)
+  }
+}
+
+extension UUserWeeklyTrackChart: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var chartContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .weeklytrackchart)
+    
+    try chartContainer.encode(tracks, forKey: .track)
+    try chartContainer.encode(attributes, forKey: .attributes)
+  }
+}
+

--- a/Sources/UmeroKit/Models/UUserWeeklyTrackChart.swift
+++ b/Sources/UmeroKit/Models/UUserWeeklyTrackChart.swift
@@ -139,4 +139,3 @@ extension UUserWeeklyTrackChart: Encodable {
     try chartContainer.encode(attributes, forKey: .attributes)
   }
 }
-

--- a/Sources/UmeroKit/Tag/UTagAttributes.swift
+++ b/Sources/UmeroKit/Tag/UTagAttributes.swift
@@ -36,16 +36,17 @@ extension UTagAttributes: Codable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    tag = try container.decode(String.self, forKey: .tag)
+    let tagName = try container.decode(String.self, forKey: .tag)
 
     func decodeValue<T: LosslessStringConvertible>(_ key: CodingKeys, as type: T.Type, name: String) throws -> T {
       let stringValue = try container.decode(String.self, forKey: key)
       guard let value = T(stringValue) else {
-        throw UmeroKitError.invalidDataFormat("\(name) is not a valid number for tag '\(tag)'")
+        throw UmeroKitError.invalidDataFormat("\(name) is not a valid number for tag '\(tagName)'")
       }
       return value
     }
 
+    self.tag = tagName
     self.page = try decodeValue(.page, as: Int.self, name: "Page")
     self.perPage = try decodeValue(.perPage, as: Int.self, name: "PerPage")
     self.totalPages = try decodeValue(.totalPages, as: Double.self, name: "TotalPages")

--- a/Sources/UmeroKit/Tag/UTagRequest.swift
+++ b/Sources/UmeroKit/Tag/UTagRequest.swift
@@ -50,4 +50,3 @@ struct UTagRequest<UTagItemType> where UTagItemType: UTagRequestable, UTagItemTy
     return model
   }
 }
-

--- a/Sources/UmeroKit/Tag/UTagRequestable.swift
+++ b/Sources/UmeroKit/Tag/UTagRequestable.swift
@@ -13,4 +13,3 @@ protocol UTagRequestable {
   /// The attributes of the tag request.
   var attributes: UTagAttributes { get }
 }
-

--- a/Sources/UmeroKit/Tag/UTagTopAlbums.swift
+++ b/Sources/UmeroKit/Tag/UTagTopAlbums.swift
@@ -39,3 +39,13 @@ extension UTagTopAlbums: Decodable {
 }
 
 extension UTagTopAlbums: UTagRequestable {}
+
+extension UTagTopAlbums: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var albumsContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .albums)
+    
+    try albumsContainer.encode(albums, forKey: .album)
+    try albumsContainer.encode(attributes, forKey: .attributes)
+  }
+}

--- a/Sources/UmeroKit/Tag/UTagTopArtists.swift
+++ b/Sources/UmeroKit/Tag/UTagTopArtists.swift
@@ -38,3 +38,13 @@ extension UTagTopArtists: Decodable {
 }
 
 extension UTagTopArtists: UTagRequestable {}
+
+extension UTagTopArtists: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var artistsContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .topartists)
+    
+    try artistsContainer.encode(artists, forKey: .artist)
+    try artistsContainer.encode(attributes, forKey: .attributes)
+  }
+}

--- a/Sources/UmeroKit/Tag/UTagTopTracks.swift
+++ b/Sources/UmeroKit/Tag/UTagTopTracks.swift
@@ -39,3 +39,13 @@ extension UTagTopTracks: Decodable {
 }
 
 extension UTagTopTracks: UTagRequestable {}
+
+extension UTagTopTracks: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MainKey.self)
+    var tracksContainer = container.nestedContainer(keyedBy: CodingKeys.self, forKey: .tracks)
+    
+    try tracksContainer.encode(tracks, forKey: .track)
+    try tracksContainer.encode(attributes, forKey: .attributes)
+  }
+}

--- a/Sources/UmeroKit/UmeroKit.swift
+++ b/Sources/UmeroKit/UmeroKit.swift
@@ -983,6 +983,7 @@ extension UmeroKit {
   ///   - to: The end date/timestamp (optional).
   ///   - extended: Whether to return extended information (optional).
   ///   - taggingtype: The type of tags to retrieve (optional).
+  ///   - tag: The tag name for personal tags (optional).
   /// - Returns: The decoded response model of type `T`.
   private func getUserData<T: Decodable>(
     _ endpoint: UserEndpoint,
@@ -993,7 +994,8 @@ extension UmeroKit {
     from: Int? = nil,
     to: Int? = nil,
     extended: Bool? = nil,
-    taggingtype: String? = nil
+    taggingtype: String? = nil,
+    tag: String? = nil
   ) async throws -> T {
     guard !apiKey.isEmpty else { throw UmeroKitError.missingAPIKey }
     guard !secret.isEmpty else { throw UmeroKitError.missingSecret }
@@ -1037,6 +1039,7 @@ extension UmeroKit {
     }
     
     addQueryItemIfPresent("taggingtype", value: taggingtype)
+    addQueryItemIfPresent("tag", value: tag)
 
     components.items = queryItems
 
@@ -1375,7 +1378,7 @@ extension UmeroKit {
   ///   ```swift
   ///  do  {
   ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
-  ///    let tags = try await umero.userPersonalTags(for: "someuser", taggingtype: "artist")
+  ///    let tags = try await umero.userPersonalTags(for: "someuser", tag: "rock", taggingtype: "artist")
   ///  } catch {
   ///    print("Error fetching personal tags: \(error).")
   ///  }
@@ -1383,17 +1386,26 @@ extension UmeroKit {
   ///
   /// - Parameters:
   ///   - username: The username (optional, defaults to authenticated user).
+  ///   - tag: The tag name to retrieve personal tags for.
   ///   - taggingtype: The type of tags to retrieve (artist, album, or track).
   ///   - limit: The number of tags to retrieve (default: 50).
   ///   - page: The page of results to retrieve (default: 1).
   /// - Returns: A `UUserPersonalTags` object containing the personal tags.
   public func userPersonalTags(
     for username: String? = nil,
+    tag: String,
     taggingtype: String,
     limit: Int = 50,
     page: Int = 1
   ) async throws -> UUserPersonalTags {
-    try await getUserData(.getPersonalTags, username: username, limit: limit, page: page, taggingtype: taggingtype)
+    try await getUserData(
+      .getPersonalTags,
+      username: username,
+      limit: limit,
+      page: page,
+      taggingtype: taggingtype,
+      tag: tag
+    )
   }
 }
 

--- a/Sources/UmeroKit/UmeroKit.swift
+++ b/Sources/UmeroKit/UmeroKit.swift
@@ -556,7 +556,7 @@ extension UmeroKit {
   ///   - page: The page of results to retrieve (default is 1).
   /// - Returns: A `UTagTopArtists` object containing the top artists for the tag.
   public func tagTopArtists(for tag: String, limit: Int = 50, page: Int = 1) async throws -> UTagTopArtists {
-    let request = UTagRequest<UTagTopArtists>(for: tag, endpoint: .getTopArtists, limit: limit, page: page)
+    let request = UTagRequest<UTagTopArtists>(for: tag, endpoint: TagEndpoint.getTopArtists, limit: limit, page: page)
     let response = try await request.response(with: apiKey)
     return response
   }
@@ -579,7 +579,7 @@ extension UmeroKit {
   ///   - page: The page of results to retrieve (default is 1).
   /// - Returns: A `UTagTopAlbums` object containing the top albums for the tag.
   public func tagTopAlbums(for tag: String, limit: Int = 50, page: Int = 1) async throws -> UTagTopAlbums {
-    let request = UTagRequest<UTagTopAlbums>(for: tag, endpoint: .getTopAlbums, limit: limit, page: page)
+    let request = UTagRequest<UTagTopAlbums>(for: tag, endpoint: TagEndpoint.getTopAlbums, limit: limit, page: page)
     let response = try await request.response(with: apiKey)
     return response
   }
@@ -602,7 +602,7 @@ extension UmeroKit {
   ///   - page: The page of results to retrieve (default is 1).
   /// - Returns: A `UTagTopTracks` object containing the top tracks for the tag.
   public func tagTopTracks(for tag: String, limit: Int = 50, page: Int = 1) async throws -> UTagTopTracks {
-    let request = UTagRequest<UTagTopTracks>(for: tag, endpoint: .getTopTracks, limit: limit, page: page)
+    let request = UTagRequest<UTagTopTracks>(for: tag, endpoint: TagEndpoint.getTopTracks, limit: limit, page: page)
     let response = try await request.response(with: apiKey)
     return response
   }
@@ -1019,33 +1019,24 @@ extension UmeroKit {
     let targetUsername = username ?? instanceUsername
     queryItems.append(URLQueryItem(name: "user", value: targetUsername))
 
-    if let limit {
-      queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+    // Helper function to conditionally add query items
+    func addQueryItemIfPresent(_ name: String, value: String?) {
+      if let value {
+        queryItems.append(URLQueryItem(name: name, value: value))
+      }
     }
 
-    if let page {
-      queryItems.append(URLQueryItem(name: "page", value: String(page)))
-    }
-
-    if let period {
-      queryItems.append(URLQueryItem(name: "period", value: period))
-    }
-
-    if let from {
-      queryItems.append(URLQueryItem(name: "from", value: String(from)))
-    }
-
-    if let to {
-      queryItems.append(URLQueryItem(name: "to", value: String(to)))
-    }
-
+    addQueryItemIfPresent("limit", value: limit.map { String($0) })
+    addQueryItemIfPresent("page", value: page.map { String($0) })
+    addQueryItemIfPresent("period", value: period)
+    addQueryItemIfPresent("from", value: from.map { String($0) })
+    addQueryItemIfPresent("to", value: to.map { String($0) })
+    
     if let extended {
       queryItems.append(URLQueryItem(name: "extended", value: "\(extended.intValue)"))
     }
-
-    if let taggingtype {
-      queryItems.append(URLQueryItem(name: "taggingtype", value: taggingtype))
-    }
+    
+    addQueryItemIfPresent("taggingtype", value: taggingtype)
 
     components.items = queryItems
 
@@ -1224,7 +1215,15 @@ extension UmeroKit {
     to: Int? = nil,
     extended: Bool = false
   ) async throws -> UUserRecentTracks {
-    try await getUserData(.getRecentTracks, username: username, limit: limit, page: page, from: from, to: to, extended: extended)
+    try await getUserData(
+      .getRecentTracks,
+      username: username,
+      limit: limit,
+      page: page,
+      from: from,
+      to: to,
+      extended: extended
+    )
   }
 
   /// Get loved tracks by a user.

--- a/Sources/UmeroKit/UmeroKit.swift
+++ b/Sources/UmeroKit/UmeroKit.swift
@@ -969,6 +969,435 @@ extension UmeroKit {
   }
 }
 
+// MARK: - USER
+extension UmeroKit {
+  /// Helper function to fetch user data from Last.fm API endpoints.
+  ///
+  /// - Parameters:
+  ///   - endpoint: The user endpoint to call.
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - limit: The number of items to retrieve (optional).
+  ///   - page: The page of results to retrieve (optional).
+  ///   - period: The time period for top items (optional).
+  ///   - from: The start date/timestamp (optional).
+  ///   - to: The end date/timestamp (optional).
+  ///   - extended: Whether to return extended information (optional).
+  ///   - taggingtype: The type of tags to retrieve (optional).
+  /// - Returns: The decoded response model of type `T`.
+  private func getUserData<T: Decodable>(
+    _ endpoint: UserEndpoint,
+    username: String? = nil,
+    limit: Int? = nil,
+    page: Int? = nil,
+    period: String? = nil,
+    from: Int? = nil,
+    to: Int? = nil,
+    extended: Bool? = nil,
+    taggingtype: String? = nil
+  ) async throws -> T {
+    guard !apiKey.isEmpty else { throw UmeroKitError.missingAPIKey }
+    guard !secret.isEmpty else { throw UmeroKitError.missingSecret }
+    guard let instanceUsername = self.username else { throw UmeroKitError.missingUsername }
+    guard let password else { throw UmeroKitError.missingPassword }
+
+    // Authenticate to get session key
+    let authRequest = UAuthDataRequest(
+      username: instanceUsername,
+      password: password,
+      apiKey: apiKey,
+      secret: secret
+    )
+    let authResponse = try await authRequest.response()
+
+    var components = UURLComponents(apiKey: apiKey, endpoint: endpoint)
+    var queryItems: [URLQueryItem] = [
+      URLQueryItem(name: "sk", value: authResponse.key)
+    ]
+
+    // Add username parameter if provided (for querying other users)
+    // If not provided, use the authenticated user's username
+    let targetUsername = username ?? instanceUsername
+    queryItems.append(URLQueryItem(name: "user", value: targetUsername))
+
+    if let limit {
+      queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+    }
+
+    if let page {
+      queryItems.append(URLQueryItem(name: "page", value: String(page)))
+    }
+
+    if let period {
+      queryItems.append(URLQueryItem(name: "period", value: period))
+    }
+
+    if let from {
+      queryItems.append(URLQueryItem(name: "from", value: String(from)))
+    }
+
+    if let to {
+      queryItems.append(URLQueryItem(name: "to", value: String(to)))
+    }
+
+    if let extended {
+      queryItems.append(URLQueryItem(name: "extended", value: "\(extended.intValue)"))
+    }
+
+    if let taggingtype {
+      queryItems.append(URLQueryItem(name: "taggingtype", value: taggingtype))
+    }
+
+    components.items = queryItems
+
+    let request = UDataRequest<T>(url: components.url)
+    return try await request.response()
+  }
+
+  /// Get user profile information.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let userInfo = try await umero.userInfo()
+  ///  } catch {
+  ///    print("Error fetching user info: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameter username: The username to get info for (optional, defaults to authenticated user).
+  /// - Returns: A `UUserInfo` object containing the user's profile information.
+  public func userInfo(for username: String? = nil) async throws -> UUserInfo {
+    try await getUserData(.getInfo, username: username)
+  }
+
+  /// Get tags applied by a user.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let tags = try await umero.userTags(for: "someuser")
+  ///  } catch {
+  ///    print("Error fetching user tags: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameter username: The username whose tags you want to retrieve (optional, defaults to authenticated user).
+  /// - Returns: An array of `UTag` objects representing the tags.
+  public func userTags(for username: String? = nil) async throws -> [UTag] {
+    let response: UUserTags = try await getUserData(.getTags, username: username)
+    return response.tags.tag
+  }
+
+  /// Get the top tags for a user on Last.fm, ordered by popularity.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let tags = try await umero.userTopTags(for: "someuser")
+  ///  } catch {
+  ///    print("Error fetching top tags: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - limit: The number of tags to retrieve (default: 50).
+  ///   - page: The page of results to retrieve (default: 1).
+  /// - Returns: A `UUserTopTags` object containing the top tags.
+  public func userTopTags(
+    for username: String? = nil,
+    limit: Int = 50,
+    page: Int = 1
+  ) async throws -> UUserTopTags {
+    try await getUserData(.getTopTags, username: username, limit: limit, page: page)
+  }
+
+  /// Get the top artists for a user on Last.fm.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let artists = try await umero.userTopArtists(for: "someuser", period: "overall")
+  ///  } catch {
+  ///    print("Error fetching top artists: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - period: The time period (overall, 7day, 1month, 3month, 6month, 12month). Default: overall.
+  ///   - limit: The number of artists to retrieve (default: 50).
+  ///   - page: The page of results to retrieve (default: 1).
+  /// - Returns: A `UUserTopArtists` object containing the top artists for the user.
+  public func userTopArtists(
+    for username: String? = nil,
+    period: String = "overall",
+    limit: Int = 50,
+    page: Int = 1
+  ) async throws -> UUserTopArtists {
+    try await getUserData(.getTopArtists, username: username, limit: limit, page: page, period: period)
+  }
+
+  /// Get the top albums for a user on Last.fm.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let albums = try await umero.userTopAlbums(for: "someuser", period: "7day")
+  ///  } catch {
+  ///    print("Error fetching top albums: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - period: The time period (overall, 7day, 1month, 3month, 6month, 12month). Default: overall.
+  ///   - limit: The number of albums to retrieve (default: 50).
+  ///   - page: The page of results to retrieve (default: 1).
+  /// - Returns: A `UUserTopAlbums` object containing the top albums for the user.
+  public func userTopAlbums(
+    for username: String? = nil,
+    period: String = "overall",
+    limit: Int = 50,
+    page: Int = 1
+  ) async throws -> UUserTopAlbums {
+    try await getUserData(.getTopAlbums, username: username, limit: limit, page: page, period: period)
+  }
+
+  /// Get the top tracks for a user on Last.fm.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let tracks = try await umero.userTopTracks(for: "someuser", period: "1month")
+  ///  } catch {
+  ///    print("Error fetching top tracks: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - period: The time period (overall, 7day, 1month, 3month, 6month, 12month). Default: overall.
+  ///   - limit: The number of tracks to retrieve (default: 50).
+  ///   - page: The page of results to retrieve (default: 1).
+  /// - Returns: A `UUserTopTracks` object containing the top tracks for the user.
+  public func userTopTracks(
+    for username: String? = nil,
+    period: String = "overall",
+    limit: Int = 50,
+    page: Int = 1
+  ) async throws -> UUserTopTracks {
+    try await getUserData(.getTopTracks, username: username, limit: limit, page: page, period: period)
+  }
+
+  /// Get recent tracks scrobbled by a user.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let tracks = try await umero.userRecentTracks(for: "someuser", limit: 10)
+  ///  } catch {
+  ///    print("Error fetching recent tracks: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - limit: The number of tracks to retrieve (default: 50).
+  ///   - page: The page of results to retrieve (default: 1).
+  ///   - from: The start timestamp (optional).
+  ///   - to: The end timestamp (optional).
+  ///   - extended: Whether to return extended information (default: false).
+  /// - Returns: A `UUserRecentTracks` object containing the recent tracks.
+  public func userRecentTracks(
+    for username: String? = nil,
+    limit: Int = 50,
+    page: Int = 1,
+    from: Int? = nil,
+    to: Int? = nil,
+    extended: Bool = false
+  ) async throws -> UUserRecentTracks {
+    try await getUserData(.getRecentTracks, username: username, limit: limit, page: page, from: from, to: to, extended: extended)
+  }
+
+  /// Get loved tracks by a user.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let tracks = try await umero.userLovedTracks(for: "someuser")
+  ///  } catch {
+  ///    print("Error fetching loved tracks: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - limit: The number of tracks to retrieve (default: 50).
+  ///   - page: The page of results to retrieve (default: 1).
+  /// - Returns: A `UUserLovedTracks` object containing the loved tracks.
+  public func userLovedTracks(
+    for username: String? = nil,
+    limit: Int = 50,
+    page: Int = 1
+  ) async throws -> UUserLovedTracks {
+    try await getUserData(.getLovedTracks, username: username, limit: limit, page: page)
+  }
+
+  /// Get the list of available weekly charts for a user.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let chartList = try await umero.userWeeklyChartList(for: "someuser")
+  ///  } catch {
+  ///    print("Error fetching weekly chart list: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameter username: The username (optional, defaults to authenticated user).
+  /// - Returns: A `UUserWeeklyChartList` object containing the list of available weekly charts.
+  public func userWeeklyChartList(for username: String? = nil) async throws -> UUserWeeklyChartList {
+    try await getUserData(.getWeeklyChartList, username: username)
+  }
+
+  /// Get a weekly album chart for a user.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let chart = try await umero.userWeeklyAlbumChart(for: "someuser", from: fromTimestamp, to: toTimestamp)
+  ///  } catch {
+  ///    print("Error fetching weekly album chart: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - from: The start timestamp of the chart period.
+  ///   - to: The end timestamp of the chart period.
+  /// - Returns: A `UUserWeeklyAlbumChart` object containing the weekly album chart.
+  public func userWeeklyAlbumChart(
+    for username: String? = nil,
+    from: Int,
+    to: Int
+  ) async throws -> UUserWeeklyAlbumChart {
+    try await getUserData(.getWeeklyAlbumChart, username: username, from: from, to: to)
+  }
+
+  /// Get a weekly artist chart for a user.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let chart = try await umero.userWeeklyArtistChart(for: "someuser", from: fromTimestamp, to: toTimestamp)
+  ///  } catch {
+  ///    print("Error fetching weekly artist chart: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - from: The start timestamp of the chart period.
+  ///   - to: The end timestamp of the chart period.
+  /// - Returns: A `UUserWeeklyArtistChart` object containing the weekly artist chart.
+  public func userWeeklyArtistChart(
+    for username: String? = nil,
+    from: Int,
+    to: Int
+  ) async throws -> UUserWeeklyArtistChart {
+    try await getUserData(.getWeeklyArtistChart, username: username, from: from, to: to)
+  }
+
+  /// Get a weekly track chart for a user.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let chart = try await umero.userWeeklyTrackChart(for: "someuser", from: fromTimestamp, to: toTimestamp)
+  ///  } catch {
+  ///    print("Error fetching weekly track chart: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - from: The start timestamp of the chart period.
+  ///   - to: The end timestamp of the chart period.
+  /// - Returns: A `UUserWeeklyTrackChart` object containing the weekly track chart.
+  public func userWeeklyTrackChart(
+    for username: String? = nil,
+    from: Int,
+    to: Int
+  ) async throws -> UUserWeeklyTrackChart {
+    try await getUserData(.getWeeklyTrackChart, username: username, from: from, to: to)
+  }
+
+  /// Get a user's friends.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let friends = try await umero.userFriends(for: "someuser")
+  ///  } catch {
+  ///    print("Error fetching friends: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - limit: The number of friends to retrieve (default: 50).
+  ///   - page: The page of results to retrieve (default: 1).
+  /// - Returns: A `UUserFriends` object containing the user's friends.
+  public func userFriends(
+    for username: String? = nil,
+    limit: Int = 50,
+    page: Int = 1
+  ) async throws -> UUserFriends {
+    try await getUserData(.getFriends, username: username, limit: limit, page: page)
+  }
+
+  /// Get personal tags applied by a user.
+  ///
+  ///  Example:
+  ///   ```swift
+  ///  do  {
+  ///    let umero = UmeroKit(apiKey: apiKey, secret: secret, username: "myusername", password: "mypassword")
+  ///    let tags = try await umero.userPersonalTags(for: "someuser", taggingtype: "artist")
+  ///  } catch {
+  ///    print("Error fetching personal tags: \(error).")
+  ///  }
+  ///  ```
+  ///
+  /// - Parameters:
+  ///   - username: The username (optional, defaults to authenticated user).
+  ///   - taggingtype: The type of tags to retrieve (artist, album, or track).
+  ///   - limit: The number of tags to retrieve (default: 50).
+  ///   - page: The page of results to retrieve (default: 1).
+  /// - Returns: A `UUserPersonalTags` object containing the personal tags.
+  public func userPersonalTags(
+    for username: String? = nil,
+    taggingtype: String,
+    limit: Int = 50,
+    page: Int = 1
+  ) async throws -> UUserPersonalTags {
+    try await getUserData(.getPersonalTags, username: username, limit: limit, page: page, taggingtype: taggingtype)
+  }
+}
+
 extension Bool {
   var intValue: Int {
     return self ? 1 : 0

--- a/Tests/UmeroKitTests/UserEndpointTests.swift
+++ b/Tests/UmeroKitTests/UserEndpointTests.swift
@@ -198,11 +198,11 @@ struct UserEndpointTests {
     }
     
     // Test URecentTrackArtist without mbid
-    let artistNoMbidJSON = """
+    let artistNoMbidJSON = Data("""
     {
       "#text": "Test Artist"
     }
-    """.data(using: .utf8)!
+    """.utf8)
     
     do {
       let artistNoMbid = try JSONDecoder().decode(URecentTrackArtist.self, from: artistNoMbidJSON)

--- a/Tests/UmeroKitTests/UserEndpointTests.swift
+++ b/Tests/UmeroKitTests/UserEndpointTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+@testable import UmeroKit
+
+@Suite("User Endpoints Tests")
+struct UserEndpointTests {
+  var umeroKit: UmeroKit {
+    UmeroKit(apiKey: "test_api_key", secret: "test_secret", username: "testuser", password: "testpass")
+  }
+
+  @Test("User info endpoint URL construction")
+  func testUserInfoURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getInfo)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.getinfo") == true)
+    #expect(components.url?.absoluteString.contains("user=testuser") == true)
+    #expect(components.url?.absoluteString.contains("api_key=test_api_key") == true)
+  }
+
+  @Test("User recent tracks endpoint URL construction")
+  func testUserRecentTracksURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getRecentTracks)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser"),
+      URLQueryItem(name: "limit", value: "10"),
+      URLQueryItem(name: "page", value: "1"),
+      URLQueryItem(name: "extended", value: "1")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.getrecenttracks") == true)
+    #expect(components.url?.absoluteString.contains("user=testuser") == true)
+    #expect(components.url?.absoluteString.contains("limit=10") == true)
+    #expect(components.url?.absoluteString.contains("extended=1") == true)
+  }
+
+  @Test("User top artists endpoint URL construction")
+  func testUserTopArtistsURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getTopArtists)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser"),
+      URLQueryItem(name: "period", value: "7day"),
+      URLQueryItem(name: "limit", value: "50"),
+      URLQueryItem(name: "page", value: "1")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.gettopartists") == true)
+    #expect(components.url?.absoluteString.contains("period=7day") == true)
+    #expect(components.url?.absoluteString.contains("limit=50") == true)
+  }
+
+  @Test("User top albums endpoint URL construction")
+  func testUserTopAlbumsURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getTopAlbums)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser"),
+      URLQueryItem(name: "period", value: "1month"),
+      URLQueryItem(name: "limit", value: "50")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.gettopalbums") == true)
+    #expect(components.url?.absoluteString.contains("period=1month") == true)
+  }
+
+  @Test("User top tracks endpoint URL construction")
+  func testUserTopTracksURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getTopTracks)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser"),
+      URLQueryItem(name: "period", value: "12month"),
+      URLQueryItem(name: "limit", value: "50")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.gettoptracks") == true)
+    #expect(components.url?.absoluteString.contains("period=12month") == true)
+  }
+
+  @Test("User loved tracks endpoint URL construction")
+  func testUserLovedTracksURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getLovedTracks)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser"),
+      URLQueryItem(name: "limit", value: "50"),
+      URLQueryItem(name: "page", value: "1")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.getlovedtracks") == true)
+    #expect(components.url?.absoluteString.contains("limit=50") == true)
+  }
+
+  @Test("User weekly chart list endpoint URL construction")
+  func testUserWeeklyChartListURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getWeeklyChartList)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.getweeklychartlist") == true)
+  }
+
+  @Test("User weekly album chart endpoint URL construction")
+  func testUserWeeklyAlbumChartURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getWeeklyAlbumChart)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser"),
+      URLQueryItem(name: "from", value: "1234567890"),
+      URLQueryItem(name: "to", value: "1234567891")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.getweeklyalbumchart") == true)
+    #expect(components.url?.absoluteString.contains("from=1234567890") == true)
+    #expect(components.url?.absoluteString.contains("to=1234567891") == true)
+  }
+
+  @Test("User personal tags endpoint URL construction")
+  func testUserPersonalTagsURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getPersonalTags)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser"),
+      URLQueryItem(name: "tag", value: "rock"),
+      URLQueryItem(name: "taggingtype", value: "artist"),
+      URLQueryItem(name: "limit", value: "50")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.getpersonaltags") == true)
+    #expect(components.url?.absoluteString.contains("tag=rock") == true)
+    #expect(components.url?.absoluteString.contains("taggingtype=artist") == true)
+  }
+
+  @Test("User friends endpoint URL construction")
+  func testUserFriendsURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getFriends)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser"),
+      URLQueryItem(name: "limit", value: "50"),
+      URLQueryItem(name: "page", value: "1")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.getfriends") == true)
+    #expect(components.url?.absoluteString.contains("limit=50") == true)
+  }
+
+  @Test("User tags endpoint URL construction")
+  func testUserTagsURL() throws {
+    var components = UURLComponents(apiKey: "test_api_key", endpoint: UserEndpoint.getTags)
+    components.items = [
+      URLQueryItem(name: "sk", value: "test_session_key"),
+      URLQueryItem(name: "user", value: "testuser"),
+      URLQueryItem(name: "artist", value: "Test Artist")
+    ]
+
+    #expect(components.url?.absoluteString.contains("method=user.gettags") == true)
+    #expect(components.url?.absoluteString.contains("artist=Test%20Artist") == true)
+  }
+
+  @Test("User response models structure")
+  func testUserResponseModelsStructure() {
+    // Test UUserRecentTracksAttributes
+    let attributes = UUserRecentTracksAttributes(
+      user: "testuser",
+      page: 1,
+      perPage: 50,
+      totalPages: 10,
+      total: 500
+    )
+    #expect(attributes.user == "testuser")
+    #expect(attributes.page == 1)
+    #expect(attributes.perPage == 50)
+    #expect(attributes.totalPages == 10)
+    #expect(attributes.total == 500)
+
+    // Test URecentTrackArtist
+    let artist = URecentTrackArtist(name: "Test Artist", mbid: UItemID(rawValue: "test-mbid"))
+    #expect(artist.name == "Test Artist")
+    #expect(artist.mbid?.rawValue == "test-mbid")
+
+    // Test URecentTrackArtist without mbid
+    let artistNoMbid = URecentTrackArtist(name: "Test Artist", mbid: nil)
+    #expect(artistNoMbid.name == "Test Artist")
+    #expect(artistNoMbid.mbid == nil)
+  }
+
+  @Test("User endpoint authentication requirements")
+  func testUserEndpointAuthenticationRequirements() async throws {
+    let umeroKitWithoutAuth = UmeroKit(apiKey: "test_api_key", secret: "test_secret")
+    
+    // All user endpoints require authentication
+    do {
+      _ = try await umeroKitWithoutAuth.userInfo(for: "testuser")
+      #expect(Bool(false), "Should have thrown error for missing username")
+    } catch {
+      #expect(error is UmeroKitError)
+    }
+  }
+
+}

--- a/Tests/UmeroKitTests/UserEndpointTests.swift
+++ b/Tests/UmeroKitTests/UserEndpointTests.swift
@@ -182,12 +182,12 @@ struct UserEndpointTests {
     #expect(attributes.total == 500)
 
     // Test URecentTrackArtist with actual API format (#text for name)
-    let artistJSON = """
+    let artistJSON = Data("""
     {
       "mbid": "4fa5eab2-270a-44e9-bc84-cf9f00766c75",
       "#text": "Mario Vazquez"
     }
-    """.data(using: .utf8)!
+    """.utf8)
     
     do {
       let artist = try JSONDecoder().decode(URecentTrackArtist.self, from: artistJSON)

--- a/Tests/UmeroKitTests/UserEndpointTests.swift
+++ b/Tests/UmeroKitTests/UserEndpointTests.swift
@@ -181,15 +181,36 @@ struct UserEndpointTests {
     #expect(attributes.totalPages == 10)
     #expect(attributes.total == 500)
 
-    // Test URecentTrackArtist
-    let artist = URecentTrackArtist(name: "Test Artist", mbid: UItemID(rawValue: "test-mbid"))
-    #expect(artist.name == "Test Artist")
-    #expect(artist.mbid?.rawValue == "test-mbid")
-
+    // Test URecentTrackArtist with actual API format (#text for name)
+    let artistJSON = """
+    {
+      "mbid": "4fa5eab2-270a-44e9-bc84-cf9f00766c75",
+      "#text": "Mario Vazquez"
+    }
+    """.data(using: .utf8)!
+    
+    do {
+      let artist = try JSONDecoder().decode(URecentTrackArtist.self, from: artistJSON)
+      #expect(artist.name == "Mario Vazquez")
+      #expect(artist.mbid?.rawValue == "4fa5eab2-270a-44e9-bc84-cf9f00766c75")
+    } catch {
+      #expect(Bool(false), "Failed to decode URecentTrackArtist: \(error)")
+    }
+    
     // Test URecentTrackArtist without mbid
-    let artistNoMbid = URecentTrackArtist(name: "Test Artist", mbid: nil)
-    #expect(artistNoMbid.name == "Test Artist")
-    #expect(artistNoMbid.mbid == nil)
+    let artistNoMbidJSON = """
+    {
+      "#text": "Test Artist"
+    }
+    """.data(using: .utf8)!
+    
+    do {
+      let artistNoMbid = try JSONDecoder().decode(URecentTrackArtist.self, from: artistNoMbidJSON)
+      #expect(artistNoMbid.name == "Test Artist")
+      #expect(artistNoMbid.mbid == nil)
+    } catch {
+      #expect(Bool(false), "Failed to decode URecentTrackArtist without mbid: \(error)")
+    }
   }
 
   @Test("User endpoint authentication requirements")


### PR DESCRIPTION
## Summary

This PR implements all 14 missing user endpoints from the Last.fm API, achieving **100% API coverage** for UmeroKit! 🎉

## Changes

### New Files
- `Sources/UmeroKit/Models/UUserInfo.swift` - User profile information model
- `Sources/UmeroKit/Models/UUserTags.swift` - User tags model
- `Sources/UmeroKit/Models/UUserTopTags.swift` - User top tags model (reuses UTopTags)
- `Sources/UmeroKit/Models/UUserTopArtists.swift` - User top artists model
- `Sources/UmeroKit/Models/UUserTopAlbums.swift` - User top albums model
- `Sources/UmeroKit/Models/UUserTopTracks.swift` - User top tracks model
- `Sources/UmeroKit/Models/UUserRecentTracks.swift` - User recent tracks model
- `Sources/UmeroKit/Models/UUserLovedTracks.swift` - User loved tracks model
- `Sources/UmeroKit/Models/UUserFriends.swift` - User friends model
- `Sources/UmeroKit/Models/UUserWeeklyChartList.swift` - Weekly chart list model
- `Sources/UmeroKit/Models/UUserWeeklyAlbumChart.swift` - Weekly album chart model
- `Sources/UmeroKit/Models/UUserWeeklyArtistChart.swift` - Weekly artist chart model
- `Sources/UmeroKit/Models/UUserWeeklyTrackChart.swift` - Weekly track chart model
- `Sources/UmeroKit/Models/UUserPersonalTags.swift` - Personal tags model

### Modified Files
- `Sources/UmeroKit/UmeroKit.swift` - Added getUserData() helper and 14 public methods
- `LASTFM_API_COVERAGE.md` - Updated to reflect 100% coverage

## API Methods Added

### Basic User Methods
- `userInfo(for:)` - Get user profile information
- `userTags(for:)` - Get tags applied by a user
- `userTopTags(for:limit:page:)` - Get top tags for a user

### Top Items Methods (with period support)
- `userTopArtists(for:period:limit:page:)` - Get top artists for a user
- `userTopAlbums(for:period:limit:page:)` - Get top albums for a user
- `userTopTracks(for:period:limit:page:)` - Get top tracks for a user

### Recent/Loved Tracks
- `userRecentTracks(for:limit:page:from:to:extended:)` - Get user's recent scrobbles
- `userLovedTracks(for:limit:page:)` - Get user's loved tracks

### Weekly Charts
- `userWeeklyChartList(for:)` - Get list of available weekly charts
- `userWeeklyAlbumChart(for:from:to:)` - Get weekly album chart
- `userWeeklyArtistChart(for:from:to:)` - Get weekly artist chart
- `userWeeklyTrackChart(for:from:to:)` - Get weekly track chart

### Other Methods
- `userFriends(for:limit:page:)` - Get user's friends
- `userPersonalTags(for:taggingtype:limit:page:)` - Get personal tags

## Implementation Details

- **Authentication**: All endpoints use session key authentication via `getUserData()` helper
- **Pagination**: Full support for limit/page parameters where applicable
- **Period Support**: Top items support period parameter (overall, 7day, 1month, 3month, 6month, 12month)
- **Timestamps**: Weekly charts support from/to timestamp parameters
- **Extended Mode**: Recent tracks support extended parameter for full track info
- **Tagging Type**: Personal tags support taggingtype parameter (artist, album, track)

## Coverage Impact

- **Before**: 34/48 endpoints (70.8%)
- **After**: 48/48 endpoints (100%) ✅

All Last.fm API endpoints are now fully covered!

## Testing

All endpoints follow existing codebase patterns and should work with the Last.fm API. Recommended next steps:
- Test authentication flow
- Verify response models match API structure
- Test pagination and optional parameters